### PR TITLE
PublicKey25519Proposition address validation fails

### DIFF
--- a/src/main/scala/scorex/core/transaction/box/proposition/PublicKey25519Proposition.scala
+++ b/src/main/scala/scorex/core/transaction/box/proposition/PublicKey25519Proposition.scala
@@ -10,7 +10,9 @@ import scala.util.{Failure, Success, Try}
 case class PublicKey25519Proposition(pubKeyBytes: Array[Byte]) extends ProofOfKnowledgeProposition[PrivateKey25519] {
   import PublicKey25519Proposition._
 
-  lazy val address: String = Base58.encode((AddressVersion +: pubKeyBytes) ++ calcCheckSum(pubKeyBytes))
+  private def bytesWithVersion: Array[Byte] = AddressVersion +: pubKeyBytes
+
+  lazy val address: String = Base58.encode(bytesWithVersion ++ calcCheckSum(bytesWithVersion))
 
   lazy val bytes = pubKeyBytes
 

--- a/src/test/scala/scorex/core/transaction/box/proposition/PublicKey25519PropositionSpecification.scala
+++ b/src/test/scala/scorex/core/transaction/box/proposition/PublicKey25519PropositionSpecification.scala
@@ -1,0 +1,18 @@
+package scorex.core.transaction.box.proposition
+
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+import org.scalatest.{Matchers, PropSpec}
+import scorex.core.transaction.state.PrivateKey25519Companion
+
+class PublicKey25519PropositionSpecification extends PropSpec
+  with PropertyChecks
+  with GeneratorDrivenPropertyChecks
+  with Matchers {
+
+  property("PublicKey25519Proposition generates valid addresses") {
+    forAll() { (seed: Array[Byte]) =>
+      val pub = PrivateKey25519Companion.generateKeys(seed)._2
+      PublicKey25519Proposition.validPubKey(pub.address).isSuccess shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
## Description

 PublicKey25519Proposition public key address validation is failing when validating checksum.

 For example:
```scala
 val pub = PrivateKey25519Companion.generateKeys(seed)._2
 PublicKey25519Proposition.validPubKey(pub.address).isSuccess == false
```
## Solution
 While creating the address, the checksum is invoked only with pubKeyBytes but when verifiying, the AddressVersion is included (`addressBytes.dropRight(ChecksumLength)` also contains the  AddressVersion in the head after droping the checksum)