### PR TITLE
Fix warnings in temporary "bitcoin.scala" file

### DIFF
--- a/src/main/scala/scorex/temp/bitcoin.scala
+++ b/src/main/scala/scorex/temp/bitcoin.scala
@@ -1,9 +1,9 @@
-package scorex.core.transaction.box.proposition
-
-import scorex.crypto.encode.Base58
-import scorex.core.transaction.proof.Proof
-
-import scala.util.{Failure, Success, Try}
+//package scorex.core.transaction.box.proposition
+//
+//import scorex.crypto.encode.Base58
+//import scorex.core.transaction.proof.Proof
+//
+//import scala.util.{Failure, Success, Try}
 
 
 //Bitcoin


### PR DESCRIPTION
All code had been commented out, except the `package` and `import` headers. This caused Scala-IDE to issue some warnings. I fixed this by commenting out the headers as well.