### PR TITLE
Replace assert by ensuring when appropriate

### DIFF
--- a/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
@@ -77,7 +77,7 @@ class HybridNodeViewHolder(settings: MiningSettings) extends NodeViewHolder[Publ
     val gw = HWallet.genesisWallet(settings, Seq(posGenesis, powGenesis))
     assert(!Base58.encode(settings.walletSeed).startsWith("genesis") || gw.boxes().map(_.box.value.toLong).sum >= GenesisBalance)
 
-    gw.boxes().foreach(b => assert(gs.closedBox(b.box.id).isDefined))
+    assert(gw.boxes().forall(b => gs.closedBox(b.box.id).isDefined))
 
     (history, gs, gw, SimpleBoxTransactionMemPool.emptyPool)
   }

--- a/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
+++ b/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
@@ -100,7 +100,7 @@ object PosBlock {
              box: PublicKey25519NoncedBox,
              attachment: Array[Byte],
              privateKey: PrivateKey25519): PosBlock = {
-    assert(box.proposition.pubKeyBytes sameElements privateKey.publicKeyBytes)
+    require(box.proposition.pubKeyBytes sameElements privateKey.publicKeyBytes)
     val unsigned = PosBlock(parentId, timestamp, txs, box, attachment, Signature25519(Signature @@ Array[Byte]()))
     val signature = Curve25519.sign(privateKey.privKeyBytes, unsigned.bytes)
     unsigned.copy(signature = Signature25519(signature))

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -27,7 +27,7 @@ case class HBoxStoredState(store: LSMStore, override val version: VersionTag) ex
     HybridBlock,
     HBoxStoredState] with ScorexLogging {
 
-  assert(store.lastVersionID.map(_.data).getOrElse(version) sameElements version,
+  require(store.lastVersionID.map(_.data).getOrElse(version) sameElements version,
     s"${Base58.encode(store.lastVersionID.map(_.data).getOrElse(version))} != ${Base58.encode(version)}")
 
   override type NVCT = HBoxStoredState

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -77,9 +77,8 @@ case class HBoxStoredState(store: LSMStore, override val version: VersionTag) ex
     store.update(ByteArrayWrapper(newVersion), boxIdsToRemove, boxesToAdd)
     val newSt = HBoxStoredState(store, newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box.data).isEmpty), s"Removed box is still in state")
-    assert(newSt.version sameElements newVersion, s"New version don't match")
     newSt
-  }
+  } ensuring { _.version sameElements newVersion, s"New version doesn't match" }
 
   override def rollbackTo(version: VersionTag): Try[HBoxStoredState] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -78,7 +78,7 @@ case class HBoxStoredState(store: LSMStore, override val version: VersionTag) ex
     val newSt = HBoxStoredState(store, newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box.data).isEmpty), s"Removed box is still in state")
     newSt
-  } ensuring { _.version sameElements newVersion }
+  } ensuring { r => if (r.isSuccess) { r.get.version sameElements newVersion } else true }
 
   override def rollbackTo(version: VersionTag): Try[HBoxStoredState] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -78,7 +78,7 @@ case class HBoxStoredState(store: LSMStore, override val version: VersionTag) ex
     val newSt = HBoxStoredState(store, newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box.data).isEmpty), s"Removed box is still in state")
     newSt
-  } ensuring { _.version sameElements newVersion, s"New version doesn't match" }
+  } ensuring { _.version sameElements newVersion }
 
   override def rollbackTo(version: VersionTag): Try[HBoxStoredState] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -47,7 +47,7 @@ object SpvAlgos {
         acc
       } else {
         val inC: Seq[Header] = constructInnerChain(suffix.head, i, boundary, headerById)
-        inC.foreach(h => assert(h.realDifficulty >= i * Constants.InitialDifficulty))
+        assert(inC.forall(h => h.realDifficulty >= i * Constants.InitialDifficulty))
         val (newIn, newB) = if (inC.length >= m) {
           (constructInnerChain(suffix.head, i, inC(inC.length - m), headerById), inC(inC.length - m))
         } else {

--- a/examples/src/main/scala/examples/trimchain/core/Algos.scala
+++ b/examples/src/main/scala/examples/trimchain/core/Algos.scala
@@ -78,8 +78,8 @@ object Algos extends App {
   def validatePow(header: BlockHeader,
                   miningStateRoots: IndexedSeq[Array[Byte]],
                   difficulty: BigInt): Boolean = Try {
-    assert(header.correctWorkDone(difficulty))
-    assert(miningStateRoots.length == k)
+    require(header.correctWorkDone(difficulty))
+    require(miningStateRoots.length == k)
 
     val nonce = header.powNonce
     val minerKey = header.ticket.minerKey

--- a/examples/src/main/scala/examples/trimchain/simulation/InMemoryAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/simulation/InMemoryAuthenticatedUtxo.scala
@@ -28,7 +28,7 @@ case class InMemoryAuthenticatedUtxo(size: Int, proverOpt: Option[ProverType], o
 
   import PublicKey25519NoncedBox.{BoxKeyLength, BoxLength}
 
-  assert(size >= 0)
+  require(size >= 0)
 
   override lazy val prover = proverOpt.getOrElse {
     val p = new ProverType(keyLength = BoxKeyLength, valueLengthOpt = Some(BoxLength)) //todo: feed it with genesis state

--- a/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
@@ -59,8 +59,8 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
 
   import PublicKey25519NoncedBox.{BoxKeyLength, BoxLength}
 
-  assert(size >= 0)
-  assert(store.lastVersionID.map(_.data).getOrElse(version) sameElements version,
+  require(size >= 0)
+  require(store.lastVersionID.map(_.data).getOrElse(version) sameElements version,
     s"${Base58.encode(store.lastVersionID.map(_.data).getOrElse(version))} != ${Base58.encode(version)}")
 
   override lazy val prover = proverOpt.getOrElse {
@@ -94,7 +94,7 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
 
   //Validate transactions in block and generator box
   override def validate(mod: TModifier): Try[Unit] = Try {
-    //    assert(mod.parentId.sameElements(version))  todo: fix & uncomment
+    //    require(mod.parentId.sameElements(version))  todo: fix & uncomment
 
     mod match {
       case u: UtxoSnapshot => if (!this.isEmpty) throw new Exception("Utxo Set already imported")

--- a/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
@@ -136,9 +136,8 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
 
     val newSt = PersistentAuthenticatedUtxo(store, size + toAdd.size - toRemove.size, Some(prover), newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box).isEmpty), s"Removed box is still in state")
-    assert(newSt.version sameElements newVersion, s"New version don't match")
     newSt
-  }
+  } ensuring { _.version sameElements newVersion, s"New version don't match" }
 
   override def rollbackTo(version: VersionTag): Try[PersistentAuthenticatedUtxo] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
@@ -137,7 +137,7 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
     val newSt = PersistentAuthenticatedUtxo(store, size + toAdd.size - toRemove.size, Some(prover), newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box).isEmpty), s"Removed box is still in state")
     newSt
-  } ensuring { _.version sameElements newVersion }
+  } ensuring { r => if (r.isSuccess) { r.get.version sameElements newVersion } else true }
 
   override def rollbackTo(version: VersionTag): Try[PersistentAuthenticatedUtxo] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
@@ -137,7 +137,7 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
     val newSt = PersistentAuthenticatedUtxo(store, size + toAdd.size - toRemove.size, Some(prover), newVersion)
     assert(boxIdsToRemove.forall(box => newSt.closedBox(box).isEmpty), s"Removed box is still in state")
     newSt
-  } ensuring { _.version sameElements newVersion, s"New version don't match" }
+  } ensuring { _.version sameElements newVersion }
 
   override def rollbackTo(version: VersionTag): Try[PersistentAuthenticatedUtxo] = Try {
     if (store.lastVersionID.exists(_.data sameElements version)) {

--- a/examples/src/test/scala/hybrid/HybridGenerators.scala
+++ b/examples/src/test/scala/hybrid/HybridGenerators.scala
@@ -237,7 +237,7 @@ trait HybridGenerators extends ExamplesCommonGenerators with FileUtils with NoSh
       SimpleBoxTransaction(from, to, fee = fee, System.currentTimeMillis())
     }.toSeq
 
-    txs.foreach { _.boxIdsToOpen.foreach { id => assert(state.closedBox(id).isDefined) } }
+    assert(txs.forall { _.boxIdsToOpen.forall { id => state.closedBox(id).isDefined } })
 
     val genBox: PublicKey25519NoncedBox = stateBoxes.head
     val generator = privKey(genBox.value)._1

--- a/src/main/scala/scorex/core/consensus/BlockChain.scala
+++ b/src/main/scala/scorex/core/consensus/BlockChain.scala
@@ -46,7 +46,7 @@ trait BlockChain[P <: Proposition, TX <: Transaction[P], B <: Block[P, TX], SI <
   override def continuationIds(info: SI, size: Int):
   Option[Seq[(ModifierTypeId, ModifierId)]] = {
     val openSurface = info.startingPoints
-    assert(openSurface.size == 1)
+    require(openSurface.size == 1)
     val modId = openSurface.head._1
     val s = lookForward(openSurface.head._2, size)
     if (s.isEmpty) None else Some(s.map(id => modId -> id))

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -53,7 +53,7 @@ object InvSpec extends MessageSpec[InvData] {
   override def toBytes(data: InvData): Array[Byte] = {
     require(data._2.nonEmpty, "empty inv list")
     require(data._2.size <= MaxObjects, s"more invs than $MaxObjects in a message")
-    data._2.foreach(e => require(e.length == NodeViewModifier.ModifierIdSize))
+    require(data._2.forall(e => e.length == NodeViewModifier.ModifierIdSize))
 
     Bytes.concat(Array(data._1), Ints.toByteArray(data._2.size), scorex.core.utils.concatBytes(data._2))
   }

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -40,8 +40,8 @@ object InvSpec extends MessageSpec[InvData] {
     val typeId = ModifierTypeId @@ bytes.head
     val count = Ints.fromByteArray(bytes.slice(1, 5))
 
-    assert(count > 0, "empty inv list")
-    assert(count <= MaxObjects, s"more invs than $MaxObjects in a message")
+    require(count > 0, "empty inv list")
+    require(count <= MaxObjects, s"more invs than $MaxObjects in a message")
 
     val elems = (0 until count).map { c =>
       ModifierId @@ bytes.slice(5 + c * NodeViewModifier.ModifierIdSize, 5 + (c + 1) * NodeViewModifier.ModifierIdSize)
@@ -129,7 +129,7 @@ object PeersSpec extends MessageSpec[Seq[InetSocketAddress]] {
     val lengthBytes = util.Arrays.copyOfRange(bytes, 0, DataLength)
     val length = Ints.fromByteArray(lengthBytes)
 
-    assert(bytes.length == DataLength + (length * (AddressLength + PortLength)), "Data does not match length")
+    require(bytes.length == DataLength + (length * (AddressLength + PortLength)), "Data does not match length")
 
     (0 until length).map { i =>
       val position = lengthBytes.length + (i * (AddressLength + PortLength))

--- a/src/main/scala/scorex/core/network/message/MessageHandler.scala
+++ b/src/main/scala/scorex/core/network/message/MessageHandler.scala
@@ -21,12 +21,12 @@ case class MessageHandler(specs: Seq[MessageSpec[_]]) {
     val magic = new Array[Byte](MagicLength)
     bytes.get(magic)
 
-    assert(magic.sameElements(Message.MAGIC), "Wrong magic bytes" + magic.mkString)
+    require(magic.sameElements(Message.MAGIC), "Wrong magic bytes" + magic.mkString)
 
     val msgCode = bytes.get
 
     val length = bytes.getInt
-    assert(length >= 0, "Data length is negative!")
+    require(length >= 0, "Data length is negative!")
 
     val msgData: Array[Byte] = length > 0 match {
       case true =>


### PR DESCRIPTION
This PR should be merged after #52.

It is more idiomatic to use `ensuring` instead of `assert` for post-conditions.