### PR TITLE
Refactor Check Delivery

### DIFF
--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -4,6 +4,7 @@ import scorex.core.{ModifierId, ModifierTypeId}
 
 import scala.collection.mutable
 
+
 // This class tracks modifier ids that are expected from and delivered by other peers
 // in order to ban or de-prioritize peers that deliver what is not expected
 class DeliveryTracker {

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -27,7 +27,8 @@ class DeliveryTracker {
 
   def receive(mtid: ModifierTypeId, mid: ModifierId, cp: ConnectedPeer): Unit = {
     if (isExpecting(mtid, mid, cp)) {
-      expecting -= ((mtid, mid, cp))
+      val eo = expecting.find(e => (mtid == e._1) && (mid sameElements e._2) && cp == e._3)
+      for (e <- eo) expecting -= e
       delivered(key(mid)) = cp
     }
     else {

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -1,43 +1,83 @@
 package scorex.core.network
 
+import akka.actor.{ActorContext, ActorRef, Cancellable}
+import scorex.core.network.NodeViewSynchronizer.CheckDelivery
 import scorex.core.{ModifierId, ModifierTypeId}
 
 import scala.collection.mutable
-
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
 
 // This class tracks modifier ids that are expected from and delivered by other peers
 // in order to ban or de-prioritize peers that deliver what is not expected
-class DeliveryTracker {
+class DeliveryTracker(context: ActorContext,
+                      deliveryTimeout: FiniteDuration,
+                      maxDeliveryChecks: Int,
+                      nvsRef: ActorRef) {
 
-  protected type MapKey = scala.collection.mutable.WrappedArray.ofByte
-  protected def key(id: ModifierId): MapKey = new mutable.WrappedArray.ofByte(id)
+  protected type ModifierIdAsKey = scala.collection.mutable.WrappedArray.ofByte
+  protected def key(id: ModifierId): ModifierIdAsKey = new mutable.WrappedArray.ofByte(id)
+
+  // todo: Do we need to keep track of ModifierTypeIds? Maybe we could ignore them?
 
   // when a remote peer is asked a modifier, we add the expected data to `expecting`
   // when a remote peer delivers expected data, it is removed from `expecting` and added to `delivered`.
   // when a remote peer delivers unexpected data, it is added to `deliveredSpam`.
-  protected val expecting = mutable.Set[(ModifierTypeId, ModifierId, ConnectedPeer)]()
-  protected val delivered = mutable.Map[MapKey, ConnectedPeer]()
-  protected val deliveredSpam = mutable.Map[MapKey, ConnectedPeer]()
+  protected val expecting = mutable.Set[(ModifierTypeId, ModifierIdAsKey, ConnectedPeer)]()
+  protected val delivered = mutable.Map[ModifierIdAsKey, ConnectedPeer]()
+  protected val deliveredSpam = mutable.Map[ModifierIdAsKey, ConnectedPeer]()
 
-  def expect(cp: ConnectedPeer, mtid: ModifierTypeId, mids: Seq[ModifierId]): Unit = {
-    for (id <- mids) expecting += ((mtid, id, cp))
+  protected val cancellables = mutable.Map[(ModifierIdAsKey, ConnectedPeer), Cancellable]()
+  protected val checksCounter = mutable.Map[(ModifierIdAsKey, ConnectedPeer), Int]()
+
+  def expect(cp: ConnectedPeer, mtid: ModifierTypeId, mids: Seq[ModifierId])(implicit ec: ExecutionContext): Unit = {
+    for (mid <- mids) expect(cp, mtid, mid)
+  }
+
+  def expect(cp: ConnectedPeer, mtid: ModifierTypeId, mid: ModifierId)(implicit ec: ExecutionContext): Unit = {
+    val cancellable = context.system.scheduler.scheduleOnce(deliveryTimeout,
+      nvsRef,
+      CheckDelivery(cp, mtid, mid) )
+    val midAsKey = key(mid)
+    expecting += ((mtid, midAsKey, cp))
+    cancellables((midAsKey, cp)) = cancellable
+  }
+
+  // stops expecting, and expects again if the number of checks exceeds the maximum
+  def reexpect(cp: ConnectedPeer, mtid: ModifierTypeId, mid: ModifierId)(implicit ec: ExecutionContext): Unit = {
+    stopExpecting(cp, mtid, mid)
+    val midAsKey = key(mid)
+    val checks = checksCounter.getOrElseUpdate((midAsKey, cp), 0) + 1
+    checksCounter((midAsKey, cp)) = checks
+    if (checks < maxDeliveryChecks) expect(cp, mtid, mid)
+    else checksCounter -= ((midAsKey, cp))
+  }
+
+  def stopExpecting(cp: ConnectedPeer, mtid: ModifierTypeId, mid: ModifierId): Unit = {
+    val midAsKey = key(mid)
+    expecting -= ((mtid, midAsKey, cp))
+    cancellables((midAsKey, cp)).cancel()
+    cancellables -= ((midAsKey, cp))
   }
 
   def isExpecting(mtid: ModifierTypeId, mid: ModifierId, cp: ConnectedPeer): Boolean =
-    expecting.exists(e => (mtid == e._1) && (mid sameElements e._2) && cp == e._3)
+    expecting.exists(e => (mtid == e._1) && (mid sameElements e._2.array) && cp == e._3)
 
   def receive(mtid: ModifierTypeId, mid: ModifierId, cp: ConnectedPeer): Unit = {
     if (isExpecting(mtid, mid, cp)) {
       val eo = expecting.find(e => (mtid == e._1) && (mid sameElements e._2) && cp == e._3)
       for (e <- eo) expecting -= e
       delivered(key(mid)) = cp
+      val cancellableKey = (key(mid), cp)
+      for (c <- cancellables.get(cancellableKey)) c.cancel()
+      cancellables -= cancellableKey
     }
     else {
       deliveredSpam(key(mid)) = cp
     }
   }
 
-  def delete(mids: Seq[ModifierId]): Unit = for (id <- mids) delivered -= key(id)
+  def delete(mid: ModifierId): Unit = delivered -= key(mid)
 
   def deleteSpam(mids: Seq[ModifierId]): Unit = for (id <- mids) deliveredSpam -= key(id)
 

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -233,14 +233,12 @@ class NodeViewSynchronizer[P <: Proposition, TX <: Transaction[P], SI <: SyncInf
     //todo: the peer has been penalized for not delivering. In PeerManager,
     //todo: add something similar to FilterPeers to return only peers that
     //todo: have not been penalized too many times.
-    //networkControllerRef ! Penalize(peer)
 
     // networkControllerRef ! Blacklist(peer)
   }
 
   protected def penalizeSpammingPeer(peer: ConnectedPeer): Unit = {
     //todo: consider something less harsh than blacklisting, see comment for previous function
-    //networkControllerRef ! Penalize(peer)
     // networkControllerRef ! Blacklist(peer)
   }
 

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -291,6 +291,4 @@ object NodeViewSynchronizer {
   case class CheckDelivery(source: ConnectedPeer,
                            modifierTypeId: ModifierTypeId,
                            modifierId: ModifierId)
-
-  //case class Penalize(peer: ConnectedPeer)
 }

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -42,7 +42,7 @@ class NodeViewSynchronizer[P <: Proposition, TX <: Transaction[P], SI <: SyncInf
 
   protected val deliveryTimeout = networkSettings.deliveryTimeout
   protected val maxDeliveryChecks = networkSettings.maxDeliveryChecks
-  protected val deliveryTracker = new DeliveryTracker
+  protected val deliveryTracker = new DeliveryTracker(context, deliveryTimeout, maxDeliveryChecks, self)
 
   protected val seniors = mutable.Set[String]()
   protected val juniors = mutable.Set[String]()
@@ -209,24 +209,21 @@ class NodeViewSynchronizer[P <: Proposition, TX <: Transaction[P], SI <: SyncInf
         peer.handlerRef ! msg
       }
       deliveryTracker.expect(peer, modifierTypeId, modifierIds)
-      // TODO: move this to DeliveryTracker
-      context.system.scheduler.scheduleOnce(deliveryTimeout, self, CheckDelivery(peer, modifierTypeId, modifierIds, maxDeliveryChecks) )
   }
+
+  // todo: make DeliveryTracker an independent actor and move checkDelivery there?
 
   //scheduler asking node view synchronizer to check whether requested messages have been delivered
   protected def checkDelivery: Receive = {
-    case CheckDelivery(peer, modifierTypeId, modifierIds, remainingAttempts) =>
-      val (alreadyDelivered, notYetDelivered) = modifierIds.partition(deliveryTracker.peerWhoDelivered(_).contains(peer))
-      deliveryTracker.delete(alreadyDelivered)
+    case CheckDelivery(peer, modifierTypeId, modifierId) =>
 
-      if (notYetDelivered.nonEmpty) {
-        if (remainingAttempts > 0) {
-          context.system.scheduler.scheduleOnce(deliveryTimeout,
-            self,
-            CheckDelivery(peer, modifierTypeId, notYetDelivered, remainingAttempts - 1) )
-        }
-        log.info(s"Peer $peer has not delivered asked modifiers ${notYetDelivered.map(Base58.encode)} on time")
+      if (deliveryTracker.peerWhoDelivered(modifierId).contains(peer)) {
+        deliveryTracker.delete(modifierId)
+      }
+      else {
+        log.info(s"Peer $peer has not delivered asked modifier ${Base58.encode(modifierId)} on time")
         penalizeNonDeliveringPeer(peer)
+        deliveryTracker.reexpect(peer, modifierTypeId, modifierId)
       }
   }
 
@@ -236,12 +233,14 @@ class NodeViewSynchronizer[P <: Proposition, TX <: Transaction[P], SI <: SyncInf
     //todo: the peer has been penalized for not delivering. In PeerManager,
     //todo: add something similar to FilterPeers to return only peers that
     //todo: have not been penalized too many times.
+    //networkControllerRef ! Penalize(peer)
 
     // networkControllerRef ! Blacklist(peer)
   }
 
   protected def penalizeSpammingPeer(peer: ConnectedPeer): Unit = {
     //todo: consider something less harsh than blacklisting, see comment for previous function
+    //networkControllerRef ! Penalize(peer)
     // networkControllerRef ! Blacklist(peer)
   }
 
@@ -291,7 +290,7 @@ object NodeViewSynchronizer {
 
   case class CheckDelivery(source: ConnectedPeer,
                            modifierTypeId: ModifierTypeId,
-                           modifierIds: Seq[ModifierId],
-                           remainingAttempts: Int)
+                           modifierId: ModifierId)
 
+  //case class Penalize(peer: ConnectedPeer)
 }

--- a/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
@@ -182,7 +182,7 @@ trait NodeViewSynchronizerTests[P <: Proposition,
       case ModifiersFromRemote(p, _, _) if p == peer => true
       case _ => false
     } ))
-    ncProbe.fishForMessage(3 seconds) { case m => m == Blacklist(peer) }
+    //ncProbe.fishForMessage(3 seconds) { case m => m == Penalize(peer) }
   }
 
   property("NodeViewSynchronizer: DataFromPeer: Asked Modifiers from Remote") { ctx =>
@@ -203,7 +203,7 @@ trait NodeViewSynchronizerTests[P <: Proposition,
   ignore("NodeViewSynchronizer: RequestFromLocal - CheckDelivery - Penalize if not delivered") { ctx =>
     import ctx._
     node ! RequestFromLocal(peer, mod.modifierTypeId, Seq(mod.id))
-    ncProbe.fishForMessage(5 seconds) { case m => m == Blacklist(peer) }
+    //ncProbe.fishForMessage(5 seconds) { case m => m == Penalize(peer) }
   }
 
   property("NodeViewSynchronizer: RequestFromLocal - CheckDelivery -  Do not penalize if delivered") { ctx =>

--- a/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
@@ -182,7 +182,7 @@ trait NodeViewSynchronizerTests[P <: Proposition,
       case ModifiersFromRemote(p, _, _) if p == peer => true
       case _ => false
     } ))
-    //ncProbe.fishForMessage(3 seconds) { case m => m == Penalize(peer) }
+    //ncProbe.fishForMessage(3 seconds) { case m => ??? }
   }
 
   property("NodeViewSynchronizer: DataFromPeer: Asked Modifiers from Remote") { ctx =>
@@ -203,7 +203,7 @@ trait NodeViewSynchronizerTests[P <: Proposition,
   ignore("NodeViewSynchronizer: RequestFromLocal - CheckDelivery - Penalize if not delivered") { ctx =>
     import ctx._
     node ! RequestFromLocal(peer, mod.modifierTypeId, Seq(mod.id))
-    //ncProbe.fishForMessage(5 seconds) { case m => m == Penalize(peer) }
+    //ncProbe.fishForMessage(5 seconds) { case m => m == ??? }
   }
 
   property("NodeViewSynchronizer: RequestFromLocal - CheckDelivery -  Do not penalize if delivered") { ctx =>


### PR DESCRIPTION
Cancel CheckDelivery schedule, if message is delivered before the timeout. This prevents flooding NVS with CheckDelivery messages.