### PR TITLE
Call by name logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,8 @@ val apiDependencies = Seq(
 )
 
 val loggingDependencies = Seq(
-  "ch.qos.logback" % "logback-classic" % "1.+",
-  "ch.qos.logback" % "logback-core" % "1.+"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.+",
+  "ch.qos.logback" % "logback-classic" % "1.+"
 )
 
 val testingDependencies = Seq(

--- a/src/main/scala/scorex/core/utils/ScorexLogging.scala
+++ b/src/main/scala/scorex/core/utils/ScorexLogging.scala
@@ -1,7 +1,7 @@
 package scorex.core.utils
 
-import org.slf4j.LoggerFactory
+import com.typesafe.scalalogging.StrictLogging
 
-trait ScorexLogging {
-  protected def log = LoggerFactory.getLogger(this.getClass)
+trait ScorexLogging extends StrictLogging {
+  @inline protected def log = logger
 }

--- a/src/test/scala/scorex/core/util/LoggingSpec.scala
+++ b/src/test/scala/scorex/core/util/LoggingSpec.scala
@@ -1,0 +1,16 @@
+package scorex.core.util
+
+import org.scalatest.{FlatSpec, Matchers}
+import scorex.core.utils.ScorexLogging
+
+class LoggingSpec extends FlatSpec with Matchers with ScorexLogging {
+
+  "Logger" should "evaluate messages only if the respective log level is enabled" in {
+    var i = 0
+    log.info(s"Info level message, should be evaluated ${i = 1} i = $i")
+    i shouldBe 1
+    log.trace(s"Trace level message, should not be evaluated ${i = 2} i = $i")
+    i shouldBe 1
+  }
+
+}


### PR DESCRIPTION
Switched to scala-logging as it provides check-enabled-idiom using Scala macros. Fixes ergoplatform/ergo#137