### PR TITLE
I-176 add wartremover checks (TraversableOps enabled)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 name := "scorex-core"
 
 lazy val commonSettings = Seq(
-  wartremoverErrors ++= Seq(Wart.Recursion),
+  wartremoverErrors ++= Seq(Wart.Recursion), // , Wart.TraversableOps
   scalaVersion := "2.12.3",
   organization := "org.scorexfoundation",
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 name := "scorex-core"
 
 lazy val commonSettings = Seq(
-  wartremoverErrors ++= Seq(Wart.Recursion), // , Wart.TraversableOps
+  wartremoverErrors ++= Seq(Wart.Recursion, Wart.TraversableOps), // , Wart.Product, Wart.Var, Wart.Null
   scalaVersion := "2.12.3",
   organization := "org.scorexfoundation",
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),

--- a/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
+++ b/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
@@ -130,7 +130,7 @@ object SimpleBoxTransaction {
       w.secretByPublicImage(b.box.proposition).map(s => (s, b.box.nonce, b.box.value))
     }.toIndexedSeq
     val canSend = from.map(_._3.toLong).sum
-    // TODO: What should we do if `w.publicKeys` is empty?
+    // TODO: fixme, What should we do if `w.publicKeys` is empty?
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val charge: (PublicKey25519Proposition, Value) = (w.publicKeys.head, Value @@ (canSend - amount - fee))
 

--- a/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
+++ b/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
@@ -130,6 +130,8 @@ object SimpleBoxTransaction {
       w.secretByPublicImage(b.box.proposition).map(s => (s, b.box.nonce, b.box.value))
     }.toIndexedSeq
     val canSend = from.map(_._3.toLong).sum
+    // TODO: What should we do if `w.publicKeys` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val charge: (PublicKey25519Proposition, Value) = (w.publicKeys.head, Value @@ (canSend - amount - fee))
 
     val outputs: IndexedSeq[(PublicKey25519Proposition, Value)] = (to :+ charge).toIndexedSeq

--- a/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
@@ -83,9 +83,14 @@ object HybridNodeViewHolder extends ScorexLogging {
       IndexedSeq(genesisAccountPriv -> Nonce @@ 0L),
       icoMembers.map(_ -> GenesisBalance),
       0L,
-      0L)).ensuring(t => Base58.encode(t.head.id) == "EKuWxCuUAg9XgVWKxsnehP9FLsF3zPSyn9yczqeBHD8S")
+      0L)).ensuring { t =>
+        t.headOption match {
+          case None        => false
+          case Some(tHead) => Base58.encode(tHead.id) == "EKuWxCuUAg9XgVWKxsnehP9FLsF3zPSyn9yczqeBHD8S"
+        }
+      }
 
-    log.debug(s"Initialize state with transaction ${genesisTxs.head} with boxes ${genesisTxs.head.newBoxes}")
+    log.debug(s"Initialize state with transaction ${genesisTxs.headOption} with boxes ${genesisTxs.headOption.map(_.newBoxes)}")
 
     val genesisBox = PublicKey25519NoncedBox(genesisAccountPriv.publicImage, Nonce @@ 0L, GenesisBalance)
     val attachment = "genesis attachment".getBytes

--- a/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
@@ -83,12 +83,12 @@ object HybridNodeViewHolder extends ScorexLogging {
       IndexedSeq(genesisAccountPriv -> Nonce @@ 0L),
       icoMembers.map(_ -> GenesisBalance),
       0L,
-      0L)).ensuring { t =>
-        t.headOption match {
-          case None        => false
-          case Some(tHead) => Base58.encode(tHead.id) == "EKuWxCuUAg9XgVWKxsnehP9FLsF3zPSyn9yczqeBHD8S"
-        }
+      0L)).ensuring { t => 
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val tHead = t.head
+        Base58.encode(tHead.id) == "EKuWxCuUAg9XgVWKxsnehP9FLsF3zPSyn9yczqeBHD8S" 
       }
+      
 
     log.debug(s"Initialize state with transaction ${genesisTxs.headOption} with boxes ${genesisTxs.headOption.map(_.newBoxes)}")
 

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -318,7 +318,7 @@ class HybridHistory(val storage: HistoryStorage,
         log.warn(s"CompareNonsense: ${other.lastPowBlockIds.toList.map(Base58.encode)} at height $height}")
         HistoryComparisonResult.Nonsense
       case 1 =>
-        // TODO: What should happen if `dSuffix` is empty?
+        // `dSuffix.head` is safe as `dSuffix.length` is 1
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val dSuffixHead = dSuffix.head
         if (dSuffixHead sameElements bestPowId) {

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -194,8 +194,12 @@ class HybridHistory(val storage: HistoryStorage,
 
     val rollbackPoint = newSuffix.headOption
 
-    val throwBlocks = oldSuffix.drop(1).map(id => modifierById(id).get)
-    val applyBlocks = newSuffix.drop(1).map(id => modifierById(id).get) ++ Seq(block)
+    // TODO: fixme, What should we do if `oldSuffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val throwBlocks = oldSuffix.tail.map(id => modifierById(id).get)
+    // TODO: fixme, What should we do if `newSuffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val applyBlocks = newSuffix.tail.map(id => modifierById(id).get) ++ Seq(block)
     require(applyBlocks.nonEmpty)
     require(throwBlocks.nonEmpty)
 
@@ -292,7 +296,10 @@ class HybridHistory(val storage: HistoryStorage,
       case None => if (otherLastPowBlocks.length <= 1) {
         Seq()
       } else {
-        divergentSuffix(otherLastPowBlocks.drop(1), newSuffix)
+        // TODO: fixme, What should we do if `otherLastPowBlocks` is empty?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val otherLastPowBlocksTail = otherLastPowBlocks.tail
+        divergentSuffix(otherLastPowBlocksTail, newSuffix)
       }
     }
   }

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -218,7 +218,7 @@ class HybridHistory(val storage: HistoryStorage,
       val lastPow = modifierById(posBlock.parentId).get.asInstanceOf[PowBlock]
       val powBlocks = lastPowBlocks(DifficultyRecalcPeriod, lastPow) //.ensuring(_.length == DifficultyRecalcPeriod)
 
-      // TODO: What should we do if `powBlocksHead` is empty?
+      // TODO: fixme, What should we do if `powBlocksHead` is empty?
       @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
       val powBlocksHead = powBlocks.head
       val realTime = lastPow.timestamp - powBlocksHead.timestamp
@@ -286,7 +286,7 @@ class HybridHistory(val storage: HistoryStorage,
   @tailrec
   private def divergentSuffix(otherLastPowBlocks: Seq[ModifierId],
                               suffixFound: Seq[ModifierId] = Seq()): Seq[ModifierId] = {
-    // TODO: What should we do if `otherLastPowBlocks` is empty? Could we return Seq[ModifierId]() in that case?
+    // TODO: fixme, What should we do if `otherLastPowBlocks` is empty? Could we return Seq[ModifierId]() in that case?
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val head = otherLastPowBlocks.head
     val newSuffix = suffixFound :+ head
@@ -296,7 +296,7 @@ class HybridHistory(val storage: HistoryStorage,
       case None => if (otherLastPowBlocks.length <= 1) {
         Seq()
       } else {
-        // TODO: fixme, What should we do if `otherLastPowBlocks` is empty?
+        // `otherLastPowBlocks.tail` is safe as its length is greater than 1
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val otherLastPowBlocksTail = otherLastPowBlocks.tail
         divergentSuffix(otherLastPowBlocksTail, newSuffix)
@@ -432,10 +432,11 @@ class HybridHistory(val storage: HistoryStorage,
     }
     (winnerChain, loserChain.takeRight(loserChain.length - i))
   } ensuring { r =>
-    val condition = for(r1 <- r._1.headOption;
-                        r2 <- r._2.headOption
-                       ) yield r1 sameElements r2
-    condition getOrElse false
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val r1 = r._1.head
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val r2 = r._2.head
+    r1 sameElements r2
   }
 
   /**

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -194,8 +194,8 @@ class HybridHistory(val storage: HistoryStorage,
 
     val rollbackPoint = newSuffix.headOption
 
-    val throwBlocks = oldSuffix.tail.map(id => modifierById(id).get)
-    val applyBlocks = newSuffix.tail.map(id => modifierById(id).get) ++ Seq(block)
+    val throwBlocks = oldSuffix.drop(1).map(id => modifierById(id).get)
+    val applyBlocks = newSuffix.drop(1).map(id => modifierById(id).get) ++ Seq(block)
     require(applyBlocks.nonEmpty)
     require(throwBlocks.nonEmpty)
 
@@ -214,7 +214,10 @@ class HybridHistory(val storage: HistoryStorage,
       val lastPow = modifierById(posBlock.parentId).get.asInstanceOf[PowBlock]
       val powBlocks = lastPowBlocks(DifficultyRecalcPeriod, lastPow) //.ensuring(_.length == DifficultyRecalcPeriod)
 
-      val realTime = lastPow.timestamp - powBlocks.head.timestamp
+      // TODO: What should we do if `powBlocksHead` is empty?
+      @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+      val powBlocksHead = powBlocks.head
+      val realTime = lastPow.timestamp - powBlocksHead.timestamp
       val brothersCount = powBlocks.map(_.brothersCount).sum
       val expectedTime = (DifficultyRecalcPeriod + brothersCount) * settings.targetBlockDelay.toMillis
       val oldPowDifficulty = storage.getPoWDifficulty(Some(lastPow.prevPosId))
@@ -225,7 +228,7 @@ class HybridHistory(val storage: HistoryStorage,
       val oldPosDifficulty = storage.getPoSDifficulty(lastPow.prevPosId)
       val newPosDiff = oldPosDifficulty * DifficultyRecalcPeriod / ((DifficultyRecalcPeriod + brothersCount) * settings.rParamX10 / 10)
       log.info(s"PoW difficulty changed at ${Base58.encode(posBlock.id)}: old $oldPowDifficulty, new $newPowDiff. " +
-        s" last: $lastPow, head: ${powBlocks.head} | $brothersCount")
+        s" last: $lastPow, head: $powBlocksHead | $brothersCount")
       log.info(s"PoS difficulty changed: old $oldPosDifficulty, new $newPosDiff")
       (newPowDiff, newPosDiff)
     } else {
@@ -279,6 +282,8 @@ class HybridHistory(val storage: HistoryStorage,
   @tailrec
   private def divergentSuffix(otherLastPowBlocks: Seq[ModifierId],
                               suffixFound: Seq[ModifierId] = Seq()): Seq[ModifierId] = {
+    // TODO: What should we do if `otherLastPowBlocks` is empty? Could we return Seq[ModifierId]() in that case?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val head = otherLastPowBlocks.head
     val newSuffix = suffixFound :+ head
     modifierById(head) match {
@@ -287,7 +292,7 @@ class HybridHistory(val storage: HistoryStorage,
       case None => if (otherLastPowBlocks.length <= 1) {
         Seq()
       } else {
-        divergentSuffix(otherLastPowBlocks.tail, newSuffix)
+        divergentSuffix(otherLastPowBlocks.drop(1), newSuffix)
       }
     }
   }
@@ -306,7 +311,10 @@ class HybridHistory(val storage: HistoryStorage,
         log.warn(s"CompareNonsense: ${other.lastPowBlockIds.toList.map(Base58.encode)} at height $height}")
         HistoryComparisonResult.Nonsense
       case 1 =>
-        if (dSuffix.head sameElements bestPowId) {
+        // TODO: What should happen if `dSuffix` is empty?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val dSuffixHead = dSuffix.head
+        if (dSuffixHead sameElements bestPowId) {
           if (other.lastPosBlockId sameElements bestPosId) {
             HistoryComparisonResult.Equal
           } else if (pairCompleted) {
@@ -317,6 +325,8 @@ class HybridHistory(val storage: HistoryStorage,
         } else HistoryComparisonResult.Younger
       case _ =>
         // +1 to include common block
+        // TODO: What would be a default value for `localSuffixLength` in order to remove the unsafe calls to get and tail?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val localSuffixLength = storage.heightOf(bestPowId).get - storage.heightOf(dSuffix.last).get
         val otherSuffixLength = dSuffix.length
 
@@ -407,14 +417,25 @@ class HybridHistory(val storage: HistoryStorage,
     def in(m: HybridBlock): Boolean = loserChain.exists(s => s sameElements m.id)
 
     val winnerChain = chainBack(forkBlock, in, limit).get.map(_._2)
-    val i = loserChain.indexWhere(id => id sameElements winnerChain.head)
+    val i = loserChain.indexWhere { id =>
+      winnerChain.headOption match {
+        case None                  => false
+        case Some(winnerChainHead) => id sameElements winnerChainHead
+      }
+    }
     (winnerChain, loserChain.takeRight(loserChain.length - i))
-  }.ensuring(r => r._1.head sameElements r._2.head)
+  } ensuring { r =>
+    val condition = for(r1 <- r._1.headOption;
+                        r2 <- r._2.headOption
+                       ) yield r1 sameElements r2
+    condition getOrElse false
+  }
 
   /**
     * Average delay in milliseconds between last $blockNum blocks starting from $block
     * Debug only
     */
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   def averageDelay(id: ModifierId, blockNum: Int): Try[Long] = Try {
     val block = modifierById(id).get
     val c = chainBack(block, isGenesis, blockNum).get.map(_._2)

--- a/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
@@ -47,7 +47,7 @@ class PowMiner(viewHolderRef: ActorRef, settings: HybridMiningSettings) extends 
         val pairCompleted = view.history.pairCompleted
         val bestPowBlock = view.history.bestPowBlock
         val bestPosId = view.history.bestPosId
-        // TODO: What should we do if `view.vault.generateNewSecret().publicKeys` is empty?
+        // TODO: fixme, What should we do if `view.vault.generateNewSecret().publicKeys` is empty?
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val pubkey = view.vault.publicKeys.headOption getOrElse view.vault.generateNewSecret().publicKeys.head
         PowMiningInfo(pairCompleted, difficulty, bestPowBlock, bestPosId, pubkey)

--- a/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
@@ -47,11 +47,9 @@ class PowMiner(viewHolderRef: ActorRef, settings: HybridMiningSettings) extends 
         val pairCompleted = view.history.pairCompleted
         val bestPowBlock = view.history.bestPowBlock
         val bestPosId = view.history.bestPosId
-        val pubkey = if (view.vault.publicKeys.nonEmpty) {
-          view.vault.publicKeys.head
-        } else {
-          view.vault.generateNewSecret().publicKeys.head
-        }
+        // TODO: What should we do if `view.vault.generateNewSecret().publicKeys` is empty?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val pubkey = view.vault.publicKeys.headOption getOrElse view.vault.generateNewSecret().publicKeys.head
         PowMiningInfo(pairCompleted, difficulty, bestPowBlock, bestPosId, pubkey)
     }
     GetDataFromCurrentView[HybridHistory,

--- a/examples/src/main/scala/examples/spv/Header.scala
+++ b/examples/src/main/scala/examples/spv/Header.scala
@@ -54,7 +54,7 @@ object HeaderSerializer extends Serializer[Header] {
       if (links.isEmpty) {
         acc
       } else {
-        val headLink: Array[Byte] = links.head
+        val headLink: Array[Byte] = links.headOption getOrElse Array[Byte]()
         val repeating: Byte = links.count(_ sameElements headLink).toByte
         interlinkBytes(links.drop(repeating), Bytes.concat(acc, Array(repeating), headLink))
       }

--- a/examples/src/main/scala/examples/spv/Header.scala
+++ b/examples/src/main/scala/examples/spv/Header.scala
@@ -54,7 +54,9 @@ object HeaderSerializer extends Serializer[Header] {
       if (links.isEmpty) {
         acc
       } else {
-        val headLink: Array[Byte] = links.headOption getOrElse Array[Byte]()
+        // `links` is not empty, it is safe to call head
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val headLink: Array[Byte] = links.head
         val repeating: Byte = links.count(_ sameElements headLink).toByte
         interlinkBytes(links.drop(repeating), Bytes.concat(acc, Array(repeating), headLink))
       }

--- a/examples/src/main/scala/examples/spv/KLS16Proof.scala
+++ b/examples/src/main/scala/examples/spv/KLS16Proof.scala
@@ -77,9 +77,13 @@ object KLS16ProofSerializer extends Serializer[KLS16Proof] {
       val bytes = h.bytes
       Bytes.concat(Shorts.toByteArray(bytes.length.toShort), bytes)
     })
+
+    // TODO: fixme, What should we do if `obj.suffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val suffixHead = obj.suffix.head
     Bytes.concat(Array(obj.m.toByte, obj.k.toByte, obj.i.toByte),
-      Shorts.toByteArray(obj.suffix.headOption.map(_.bytes.length.toShort) getOrElse 0),
-      obj.suffix.headOption.map(_.bytes) getOrElse Array[Byte](),
+      Shorts.toByteArray(suffixHead.bytes.length.toShort),
+      suffixHead.bytes,
       suffixTailBytes,
       Shorts.toByteArray(obj.innerchain.length.toShort),
       interchainBytes)

--- a/examples/src/main/scala/examples/spv/KLS16Proof.scala
+++ b/examples/src/main/scala/examples/spv/KLS16Proof.scala
@@ -65,7 +65,9 @@ case class KLS16Proof(m: Int,
 
 object KLS16ProofSerializer extends Serializer[KLS16Proof] {
   override def toBytes(obj: KLS16Proof): Array[Byte] = {
-    val suffixTailBytes = scorex.core.utils.concatBytes(obj.suffix.drop(1).map { h =>
+    // TODO: fixme, What should we do if `obj.suffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val suffixTailBytes = scorex.core.utils.concatBytes(obj.suffix.tail.map { h =>
       val bytes = HeaderSerializer.bytesWithoutInterlinks(h)
       Bytes.concat(Shorts.toByteArray(bytes.length.toShort), bytes)
     })

--- a/examples/src/main/scala/examples/spv/KLS16Proof.scala
+++ b/examples/src/main/scala/examples/spv/KLS16Proof.scala
@@ -20,9 +20,11 @@ case class KLS16Proof(m: Int,
       a.parentId
     }
 
-    for(firstSuffix    <- suffix.headOption;
-        lastInnerchain <- innerchain.lastOption
-       ) require(firstSuffix.interlinks(i) sameElements lastInnerchain.id)
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val firstSuffix = suffix.head
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val lastInnerchain = innerchain.last
+    require(firstSuffix.interlinks(i) sameElements lastInnerchain.id)
 
 
     val difficulty: BigInt = Constants.InitialDifficulty * Math.pow(2, i).toInt
@@ -95,7 +97,7 @@ object KLS16ProofSerializer extends Serializer[KLS16Proof] {
       else {
         val l = Shorts.fromByteArray(bytes.slice(index, index + 2))
         val headerWithoutInterlinks = HeaderSerializer.parseBytes(bytes.slice(index + 2, index + 2 + l)).get
-        //TODO: Review this logic, what should happen if `acc` is empty?
+        //TODO: fixme, What should happen if `acc` is empty?
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val interlinks = SpvAlgos.constructInterlinkVector(acc.head)
         parseSuffixes(index + 2 + l, headerWithoutInterlinks.copy(interlinks = interlinks) +: acc)

--- a/examples/src/main/scala/examples/spv/KMZProof.scala
+++ b/examples/src/main/scala/examples/spv/KMZProof.scala
@@ -60,7 +60,7 @@ object KMZProofSerializer extends Serializer[KMZProof] {
       if (acc.length == k) (index, acc.reverse)
       else {
         val headerWithoutInterlinks = HeaderSerializer.parseBytes(bytes.slice(index, index + l)).get
-        // TODO: What should we do if `acc` is empty?
+        // TODO: fixme, What should we do if `acc` is empty?
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val interlinks = SpvAlgos.constructInterlinkVector(acc.head)
         parseSuffixes(index + l, headerWithoutInterlinks.copy(interlinks = interlinks) +: acc)

--- a/examples/src/main/scala/examples/spv/KMZProof.scala
+++ b/examples/src/main/scala/examples/spv/KMZProof.scala
@@ -37,9 +37,12 @@ object KMZProofSerializer extends Serializer[KMZProof] {
       Shorts.toByteArray(chain.length.toShort) ++ chain.flatMap(_.id)
     })
 
+    // TODO: fixme, What should we do if `obj.suffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val suffixHead = obj.suffix.head
     Bytes.concat(Array(obj.m.toByte, obj.k.toByte),
-      Shorts.toByteArray(obj.suffix.headOption.map(_.bytes.length.toShort) getOrElse 0),
-      obj.suffix.headOption.map(_.bytes) getOrElse Array[Byte](),
+      Shorts.toByteArray(suffixHead.bytes.length.toShort),
+      suffixHead.bytes,
       suffixTailBytes,
       Shorts.toByteArray(prefixHeaders.size.toShort),
       prefixHeadersBytes,

--- a/examples/src/main/scala/examples/spv/KMZProof.scala
+++ b/examples/src/main/scala/examples/spv/KMZProof.scala
@@ -23,7 +23,9 @@ object KMZProofSerializer extends Serializer[KMZProof] {
 
 
   override def toBytes(obj: KMZProof): Array[Byte] = {
-    val suffixTailBytes = scorex.core.utils.concatBytes(obj.suffix.drop(1).map { h =>
+    // TODO: fixme, What should we do if `obj.suffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val suffixTailBytes = scorex.core.utils.concatBytes(obj.suffix.tail.map { h =>
       HeaderSerializer.bytesWithoutInterlinks(h)
     })
     val prefixHeaders: Map[String, Header] = obj.prefixProofs.flatten.map(h => h.encodedId -> h).toMap

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -15,6 +15,8 @@ object SpvAlgos {
   }
 
   def constructInterlinkVector(parent: Header): Seq[Array[Byte]] = {
+    // TODO: What should we do if `parent.interlinks` is empty? Can we return an empty sequence here?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val genesisId = parent.interlinks.head
 
     @tailrec
@@ -38,6 +40,8 @@ object SpvAlgos {
 
     val (prefix, suffix: Seq[Header]) = C.splitAt(C.length - k)
 
+    // TODO: What would be a more meaningful name for `i`? We also need a default value when `prefix` is empty
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val i = prefix.last.interlinks.size - 1
     val blockchainMap: Map[ByteArrayWrapper, Header] = C.map(b => ByteArrayWrapper(b.id) -> b).toMap
     def headerById(id: Array[Byte]): Header = blockchainMap(ByteArrayWrapper(id))
@@ -48,10 +52,13 @@ object SpvAlgos {
       if (i == 0) {
         acc
       } else {
-        val inC: Seq[Header] = constructInnerChain(suffix.head, i, boundary, headerById)
+        // TODO: What should we do if `suffix` is empty?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val firstSuffix: Header = suffix.head
+        val inC: Seq[Header] = constructInnerChain(firstSuffix, i, boundary, headerById)
           .ensuring(_.forall(h => h.realDifficulty >= i * Constants.InitialDifficulty))
         val (newIn, newB) = if (inC.length >= m) {
-          (constructInnerChain(suffix.head, i, inC(inC.length - m), headerById), inC(inC.length - m))
+          (constructInnerChain(firstSuffix, i, inC(inC.length - m), headerById), inC(inC.length - m))
         } else {
           (inC, boundary)
         }
@@ -61,6 +68,8 @@ object SpvAlgos {
       }
     }
 
+    // TODO: What should we do if `C` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val boundary = C.head
     val proofChains = prove(boundary, i, Seq())
 
@@ -102,6 +111,8 @@ object SpvAlgos {
     require(k > 0 && k < blockchain.length, s"$k > 0 && $k < ${blockchain.length}")
 
     val (_, suffix: Seq[Header]) = blockchain.splitAt(blockchain.length - k)
+    // TODO: What should we do if `firstSuffix` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val firstSuffix = suffix.head
 
     //TODO make efficient
@@ -113,12 +124,14 @@ object SpvAlgos {
     def constructProof(i: Int): (Int, Seq[Header]) = {
       @tailrec
       def loop(acc: Seq[Header]): Seq[Header] = {
+        // TODO: What should we do if `acc` is empty?
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val interHeader = acc.head
         if (interHeader.interlinks.length > i) {
           val header = headerById(interHeader.interlinks(i))
           loop(header +: acc)
         } else {
-          acc.reverse.tail.reverse
+          acc dropRight 1
         }
       }
 

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -15,7 +15,7 @@ object SpvAlgos {
   }
 
   def constructInterlinkVector(parent: Header): Seq[Array[Byte]] = {
-    // TODO: What should we do if `parent.interlinks` is empty? Can we return an empty sequence here?
+    // TODO: fixme, What should we do if `parent.interlinks` is empty? Can we return an empty sequence here?
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val genesisId = parent.interlinks.head
 
@@ -52,7 +52,8 @@ object SpvAlgos {
       if (i == 0) {
         acc
       } else {
-        // TODO: What should we do if `suffix` is empty?
+        // TODO: `suffix.head` seems to be safe due to the requirement that k < C.length
+        //       at the definition of `suffix`
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val firstSuffix: Header = suffix.head
         val inC: Seq[Header] = constructInnerChain(firstSuffix, i, boundary, headerById)
@@ -68,7 +69,9 @@ object SpvAlgos {
       }
     }
 
-    // TODO: What should we do if `C` is empty?
+    // TODO: `C.head` seems to be safe as it is required that
+    //       `0 < m < C.longth` and `0 < k < C.longth` at
+    //        the begining of this method
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val boundary = C.head
     val proofChains = prove(boundary, i, Seq())
@@ -111,7 +114,7 @@ object SpvAlgos {
     require(k > 0 && k < blockchain.length, s"$k > 0 && $k < ${blockchain.length}")
 
     val (_, suffix: Seq[Header]) = blockchain.splitAt(blockchain.length - k)
-    // TODO: What should we do if `firstSuffix` is empty?
+    // TODO: `firstSuffix.head` seems to be safe due to th requirement that k < blockchain.length
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val firstSuffix = suffix.head
 
@@ -124,7 +127,7 @@ object SpvAlgos {
     def constructProof(i: Int): (Int, Seq[Header]) = {
       @tailrec
       def loop(acc: Seq[Header]): Seq[Header] = {
-        // TODO: What should we do if `acc` is empty?
+        // TODO: fixme, What should we do if `acc` is empty?
         @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val interHeader = acc.head
         if (interHeader.interlinks.length > i) {

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -40,7 +40,7 @@ object SpvAlgos {
 
     val (prefix, suffix: Seq[Header]) = C.splitAt(C.length - k)
 
-    // TODO: What would be a more meaningful name for `i`? We also need a default value when `prefix` is empty
+    // TODO: fixme, What would be a more meaningful name for `i`? We also need a default value when `prefix` is empty
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val i = prefix.last.interlinks.size - 1
     val blockchainMap: Map[ByteArrayWrapper, Header] = C.map(b => ByteArrayWrapper(b.id) -> b).toMap
@@ -125,16 +125,17 @@ object SpvAlgos {
 
     @tailrec
     def constructProof(i: Int): (Int, Seq[Header]) = {
+
+      // TODO: `acc` is never empty here, we may add a require stating so
       @tailrec
+      @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
       def loop(acc: Seq[Header]): Seq[Header] = {
-        // TODO: fixme, What should we do if `acc` is empty?
-        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
         val interHeader = acc.head
         if (interHeader.interlinks.length > i) {
           val header = headerById(interHeader.interlinks(i))
           loop(header +: acc)
         } else {
-          acc dropRight 1
+          acc.init
         }
       }
 

--- a/examples/src/main/scala/examples/spv/simulation/SPVSimulator.scala
+++ b/examples/src/main/scala/examples/spv/simulation/SPVSimulator.scala
@@ -16,7 +16,7 @@ object SPVSimulator extends App with ScorexLogging with SimulatorFuctions {
   val st = System.currentTimeMillis()
   val headerChain = genChain(Height, Difficulty, stateRoot, IndexedSeq(genesis))
 
-  val lastBlock = headerChain.last
+  val lastBlock: Option[Header] = headerChain.lastOption
   var minDiff = Difficulty
 
   val k = 6

--- a/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
+++ b/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
@@ -44,7 +44,7 @@ trait SimulatorFuctions {
                stateRoot: Array[Byte],
                transactionsRoot: Array[Byte],
                timestamp: Timestamp): Header = {
-    //TODO: Review this logic, what should happen if `parents` is empty?
+    //TODO: fixme, What should happen if `parents` is empty?
     @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val parent = parents.head
     val interlinks: Seq[Array[Byte]] = if (parents.length > 1) SpvAlgos.constructInterlinkVector(parent)

--- a/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
+++ b/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
@@ -44,6 +44,8 @@ trait SimulatorFuctions {
                stateRoot: Array[Byte],
                transactionsRoot: Array[Byte],
                timestamp: Timestamp): Header = {
+    //TODO: Review this logic, what should happen if `parents` is empty?
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
     val parent = parents.head
     val interlinks: Seq[Array[Byte]] = if (parents.length > 1) SpvAlgos.constructInterlinkVector(parent)
     else Seq(parent.id)

--- a/examples/src/main/scala/examples/trimchain/simulation/SpaceSavingsCalculator.scala
+++ b/examples/src/main/scala/examples/trimchain/simulation/SpaceSavingsCalculator.scala
@@ -18,7 +18,9 @@ object SpaceSavingsCalculator extends App {
 
   //  println(lines.head)
 
-  val data = lines.drop(1).take(finish).map(_.split(","))
+  // TODO: fixme, What should we do if `lines` is empty?
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+  val data = lines.tail.take(finish).map(_.split(","))
 
   val blockSizes = data.map(_.apply(8)).map(_.toLong)
 

--- a/examples/src/main/scala/examples/trimchain/simulation/SpaceSavingsCalculator.scala
+++ b/examples/src/main/scala/examples/trimchain/simulation/SpaceSavingsCalculator.scala
@@ -18,7 +18,7 @@ object SpaceSavingsCalculator extends App {
 
   //  println(lines.head)
 
-  val data = lines.tail.take(finish).map(_.split(","))
+  val data = lines.drop(1).take(finish).map(_.split(","))
 
   val blockSizes = data.map(_.apply(8)).map(_.toLong)
 

--- a/examples/src/test/scala/hybrid/ModifierGenerators.scala
+++ b/examples/src/test/scala/hybrid/ModifierGenerators.scala
@@ -15,6 +15,7 @@ import scorex.crypto.encode.Base58
 import scorex.crypto.hash.Blake2b256
 import scorex.testkit.generators.CoreGenerators
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 trait ModifierGenerators {
   this: HybridGenerators with CoreGenerators =>
 

--- a/examples/src/test/scala/hybrid/NodeViewHolderGenerators.scala
+++ b/examples/src/test/scala/hybrid/NodeViewHolderGenerators.scala
@@ -8,6 +8,7 @@ import io.iohk.iodb.ByteArrayWrapper
 import scorex.core.VersionTag
 import scorex.core.utils.{ByteStr, NetworkTimeProvider}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 trait NodeViewHolderGenerators { this: ModifierGenerators with StateGenerators with HistoryGenerators with HybridTypes =>
 
   class NodeViewHolderForTests(h: HT, s: ST) extends HybridNodeViewHolder(settings.scorexSettings, settings.mining, new NetworkTimeProvider(settings.scorexSettings.ntp)) {

--- a/examples/src/test/scala/hybrid/NodeViewSynchronizerGenerators.scala
+++ b/examples/src/test/scala/hybrid/NodeViewSynchronizerGenerators.scala
@@ -11,7 +11,7 @@ import scorex.core.app.Version
 import scorex.core.utils.NetworkTimeProvider
 import scorex.testkit.generators.CoreGenerators
 
-
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 trait NodeViewSynchronizerGenerators {
   this: ModifierGenerators with StateGenerators with HistoryGenerators with HybridTypes with CoreGenerators with ExamplesCommonGenerators =>
 

--- a/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
+++ b/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
@@ -9,7 +9,7 @@ import scorex.core.consensus.History.HistoryComparisonResult
 import scorex.core.{ModifierId, ModifierTypeId}
 import scorex.crypto.encode.Base58
 
-
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class HybridHistorySpecification extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks

--- a/examples/src/test/scala/hybrid/history/IODBSpecification.scala
+++ b/examples/src/test/scala/hybrid/history/IODBSpecification.scala
@@ -11,6 +11,7 @@ import scorex.core.ModifierId
 import scorex.crypto.encode.Base58
 import scorex.testkit.utils.FileUtils
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class IODBSpecification extends fixture.PropSpec
   with GeneratorDrivenPropertyChecks
   with Matchers

--- a/examples/src/test/scala/hybrid/serialization/SerializationTests.scala
+++ b/examples/src/test/scala/hybrid/serialization/SerializationTests.scala
@@ -10,6 +10,7 @@ import org.scalatest.{Matchers, PropSpec}
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.wallet.{WalletBox, WalletBoxSerializer}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class SerializationTests extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks

--- a/examples/src/test/scala/hybrid/state/SimpleBoxTransactionSpecification.scala
+++ b/examples/src/test/scala/hybrid/state/SimpleBoxTransactionSpecification.scala
@@ -13,6 +13,7 @@ import scorex.crypto.encode.Base58
 import scorex.crypto.hash.Sha256
 import scorex.crypto.signatures.{PublicKey, Signature}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class SimpleBoxTransactionSpecification extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks

--- a/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
+++ b/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
@@ -15,6 +15,7 @@ import scorex.crypto.signatures.Signature
 import scala.annotation.tailrec
 import scala.util.Random
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class HWalletSpecification extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks

--- a/examples/src/test/scala/spv/ChainTests.scala
+++ b/examples/src/test/scala/spv/ChainTests.scala
@@ -11,7 +11,7 @@ import scorex.crypto.hash.Blake2b256
 
 import scala.util.{Failure, Try}
 
-
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class ChainTests extends PropSpec
   with PropertyChecks
   with GeneratorDrivenPropertyChecks

--- a/src/main/scala/scorex/core/api/http/CompositeHttpService.scala
+++ b/src/main/scala/scorex/core/api/http/CompositeHttpService.scala
@@ -18,6 +18,7 @@ case class CompositeHttpService(system: ActorSystem, routes: Seq[ApiRoute], sett
     redirect("/swagger", StatusCodes.PermanentRedirect)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
   val compositeRoute = routes.map(_.route).reduce(_ ~ _) ~ corsHandler(swaggerService.route) ~
     path("swagger") {
       getFromResource("swagger-ui/index.html")

--- a/src/main/scala/scorex/core/consensus/BlockChain.scala
+++ b/src/main/scala/scorex/core/consensus/BlockChain.scala
@@ -47,9 +47,11 @@ trait BlockChain[P <: Proposition, TX <: Transaction[P], B <: Block[P, TX], SI <
   Option[Seq[(ModifierTypeId, ModifierId)]] = {
     val openSurface = info.startingPoints
     require(openSurface.size == 1)
-    val maybeModId: Option[ModifierTypeId] = openSurface.headOption map (_._1)
-    val s = lookForward(openSurface.headOption map (_._2), size)
-    for(modId <- maybeModId if s.nonEmpty) yield s map (id => modId -> id)
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val modId = openSurface.head._1
+    @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+    val s = lookForward(openSurface.head._2, size)
+    if (s.isEmpty) None else Some(s.map(id => modId -> id))
   }
 
   /**
@@ -73,12 +75,9 @@ trait BlockChain[P <: Proposition, TX <: Transaction[P], B <: Block[P, TX], SI <
   /**
     * Return howMany blocks starting from parentSignature
     */
-  def lookForward(maybeParentSignature: Option[ModifierId], howMany: Int): Seq[ModifierId] = maybeParentSignature match {
-    case None => Seq()
-    case Some(parentSignature) => heightOf(parentSignature).map { h =>
-      (h + 1).to(Math.min(height(), h + howMany: Int)).flatMap(blockAt).map(_.id)
-    }.getOrElse(Seq())
-  }
+  def lookForward(parentSignature: ModifierId, howMany: Int): Seq[ModifierId] = heightOf(parentSignature).map { h =>
+    (h + 1).to(Math.min(height(), h + howMany: Int)).flatMap(blockAt).map(_.id)
+  }.getOrElse(Seq())
 
   def children(blockId: ModifierId): Seq[B]
 

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -308,11 +308,13 @@ MR <: MempoolReader[TX]](networkControllerRef: ActorRef,
   //local node sending out objects requested to remote
   protected def responseFromLocal: Receive = {
     case ResponseFromLocal(peer, _, modifiers: Seq[NodeViewModifier]) =>
-      if (modifiers.nonEmpty) {
-        val modType = modifiers.head.modifierTypeId
-        val m = modType -> modifiers.map(m => m.id -> m.bytes).toMap
-        val msg = Message(ModifiersSpec, Right(m), None)
-        peer.handlerRef ! msg
+      modifiers.headOption match {
+        case None                => // do nothing
+        case Some(firstModifier) =>
+          val modType = firstModifier.modifierTypeId
+          val m = modType -> modifiers.map(m => m.id -> m.bytes).toMap
+          val msg = Message(ModifiersSpec, Right(m), None)
+          peer.handlerRef ! msg
       }
   }
 

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -308,13 +308,12 @@ MR <: MempoolReader[TX]](networkControllerRef: ActorRef,
   //local node sending out objects requested to remote
   protected def responseFromLocal: Receive = {
     case ResponseFromLocal(peer, _, modifiers: Seq[NodeViewModifier]) =>
-      modifiers.headOption match {
-        case None                => // do nothing
-        case Some(firstModifier) =>
-          val modType = firstModifier.modifierTypeId
-          val m = modType -> modifiers.map(m => m.id -> m.bytes).toMap
-          val msg = Message(ModifiersSpec, Right(m), None)
-          peer.handlerRef ! msg
+      if (modifiers.nonEmpty) {
+        @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
+        val modType = modifiers.head.modifierTypeId
+        val m = modType -> modifiers.map(m => m.id -> m.bytes).toMap
+        val msg = Message(ModifiersSpec, Right(m), None)
+        peer.handlerRef ! msg
       }
   }
 

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -111,7 +111,7 @@ object ModifiersSpec extends MessageSpec[ModifiersData] {
     val modifiers = data._2
     Array(typeId) ++ Ints.toByteArray(modifiers.size) ++ modifiers.map { case (id, modifier) =>
       id ++ Ints.toByteArray(modifier.length) ++ modifier
-    }.reduce(_ ++ _)
+    }.fold(Array[Byte]())(_ ++ _)
   }
 }
 

--- a/src/main/scala/scorex/core/utils/utils.scala
+++ b/src/main/scala/scorex/core/utils/utils.scala
@@ -55,8 +55,11 @@ package object utils {
     result
   }
 
-  def concatFixLengthBytes(seq: Traversable[Array[Byte]]): Array[Byte] = if(seq.isEmpty) Array[Byte]()
-  else concatFixLengthBytes(seq, seq.head.length)
+  def concatFixLengthBytes(seq: Traversable[Array[Byte]]): Array[Byte] = seq.headOption match {
+    case None       => Array[Byte]()
+    case Some(head) => concatFixLengthBytes(seq, head.length)
+  }
+
 
   def concatFixLengthBytes(seq: Traversable[Array[Byte]], length: Int): Array[Byte] = {
     val result: Array[Byte] = new Array[Byte](seq.toSeq.length * length)

--- a/testkit/src/main/scala/scorex/testkit/properties/NodeViewHolderTests.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/NodeViewHolderTests.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 trait NodeViewHolderTests[P <: Proposition,
 TX <: Transaction[P],
 PM <: PersistentNodeViewModifier,

--- a/testkit/src/main/scala/scorex/testkit/properties/state/box/BoxStateRollbackTest.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/state/box/BoxStateRollbackTest.scala
@@ -81,6 +81,7 @@ trait BoxStateRollbackTest[P <: Proposition,
       check { _ =>
         rollbackVersionOpt match {
           case None =>
+            @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
             val randomTx = txPair.head
             val block = semanticallyValidModifierWithCustomTransactions(state, Seq(randomTx))
             val blockChanges = newState.changes(block).get


### PR DESCRIPTION
This PR shows the errors pointed by the WartRemover plugin using the `TraversableOps` wart as commented in #176 

The results show that the code is currently unsafe in some parts. 
During the implementation I noticed other unsafe practices such as using `get` on Option and Try instances.