### PR TITLE
I-176: add wartremover checks (Recursion)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 name := "scorex-core"
 
 lazy val commonSettings = Seq(
+  wartremoverErrors ++= Seq(Wart.Recursion),
   scalaVersion := "2.12.3",
   organization := "org.scorexfoundation",
   licenses := Seq("CC0" -> url("https://creativecommons.org/publicdomain/zero/1.0/legalcode")),

--- a/examples/src/main/scala/examples/spv/Header.scala
+++ b/examples/src/main/scala/examples/spv/Header.scala
@@ -49,6 +49,7 @@ case class Header(parentId: BlockId,
 
 object HeaderSerializer extends Serializer[Header] {
   override def toBytes(h: Header): Array[Byte] = {
+    @tailrec
     def interlinkBytes(links: Seq[Array[Byte]], acc: Array[Byte]): Array[Byte] = {
       if (links.isEmpty) {
         acc

--- a/examples/src/main/scala/examples/spv/KLS16Proof.scala
+++ b/examples/src/main/scala/examples/spv/KLS16Proof.scala
@@ -3,6 +3,7 @@ package examples.spv
 import com.google.common.primitives.{Bytes, Shorts}
 import scorex.core.serialization.Serializer
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 case class KLS16Proof(m: Int,
@@ -83,6 +84,7 @@ object KLS16ProofSerializer extends Serializer[KLS16Proof] {
     val i = bytes(2)
     val headSuffixLength = Shorts.fromByteArray(bytes.slice(3, 5))
     val headSuffix = HeaderSerializer.parseBytes(bytes.slice(5, 5 + headSuffixLength)).get
+    @tailrec
     def parseSuffixes(index: Int, acc: Seq[Header]): (Int, Seq[Header]) = {
       if (acc.length == k) (index, acc.reverse)
       else {

--- a/examples/src/main/scala/examples/spv/KMZProof.scala
+++ b/examples/src/main/scala/examples/spv/KMZProof.scala
@@ -4,6 +4,7 @@ import com.google.common.primitives.{Bytes, Shorts}
 import scorex.core.serialization.Serializer
 import scorex.crypto.encode.Base58
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 case class KMZProof(m: Int, k: Int, prefixProofs: Seq[Seq[Header]], suffix: Seq[Header]) {
@@ -52,6 +53,7 @@ object KMZProofSerializer extends Serializer[KMZProof] {
     val headSuffix = HeaderSerializer.parseBytes(bytes.slice(4, 4 + headSuffixLength)).get
     val l = HeaderSerializer.BytesWithoutInterlinksLength
 
+    @tailrec
     def parseSuffixes(index: Int, acc: Seq[Header]): (Int, Seq[Header]) = {
       if (acc.length == k) (index, acc.reverse)
       else {

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -17,6 +17,7 @@ object SpvAlgos {
   def constructInterlinkVector(parent: Header): Seq[Array[Byte]] = {
     val genesisId = parent.interlinks.head
 
+    @tailrec
     def generateInnerchain(curDifficulty: BigInt, acc: Seq[Array[Byte]]): Seq[Array[Byte]] = {
       if (parent.realDifficulty >= curDifficulty) {
         generateInnerchain(curDifficulty * 2, acc :+ parent.id)
@@ -42,6 +43,7 @@ object SpvAlgos {
     def headerById(id: Array[Byte]): Header = blockchainMap(ByteArrayWrapper(id))
 
     //Algorithm 3 from the KMZ paper
+    @tailrec
     def prove(boundary: Header, i: Int, acc: Seq[Seq[Header]]): Seq[Seq[Header]] = {
       if (i == 0) {
         acc

--- a/lock.sbt
+++ b/lock.sbt
@@ -42,4 +42,4 @@ dependencyOverrides in ThisBuild ++= Seq(
   "org.typelevel" % "macro-compat_2.12" % "1.1.1",
   "org.whispersystems" % "curve25519-java" % "0.4.1"
 )
-// LIBRARY_DEPENDENCIES_HASH d01222b74993e3faa18d4bfecf4714b9688a287d
+// LIBRARY_DEPENDENCIES_HASH e7ba0232e9c21b5b9111a127fc992f8784af3365

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
+
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")


### PR DESCRIPTION
Wart `Recursion` was enabled and applied as proposed in #176

`tailrec` annotations were added in cases that were missing. No major changes were needed.