### PR TITLE
Re-fixed logic for outgoing connection to peers

### DIFF
--- a/examples/src/main/scala/examples/hybrid/HybridApp.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridApp.scala
@@ -29,8 +29,8 @@ class HybridApp(val settingsFilename: String) extends Application {
   override type PMOD = HybridBlock
   override type NVHT = HybridNodeViewHolder
 
-  private val hybridSettings = HybridSettings.read(Some(settingsFilename))
-  implicit override lazy val settings: ScorexSettings = HybridSettings.read(Some(settingsFilename)).scorexSettings
+  private lazy val hybridSettings = HybridSettings.read(Some(settingsFilename))
+  implicit override lazy val settings: ScorexSettings = hybridSettings.scorexSettings
 
   log.debug(s"Starting application with settings \n$settings")
 

--- a/src/main/scala/scorex/core/api/http/PeersApiRoute.scala
+++ b/src/main/scala/scorex/core/api/http/PeersApiRoute.scala
@@ -9,6 +9,8 @@ import io.circe.Encoder
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import scorex.core.api.http.PeersApiRoute.{BlacklistedPeers, PeerInfoResponse}
+import scorex.core.network.peer.PeerManager.ReceivableMessages._
+import scorex.core.network.NetworkController.ReceivableMessages.ConnectTo
 import scorex.core.network.Handshake
 import scorex.core.network.peer.PeerInfo
 import scorex.core.settings.RESTApiSettings
@@ -19,9 +21,6 @@ case class PeersApiRoute(peerManager: ActorRef,
                          networkController: ActorRef,
                          override val settings: RESTApiSettings)(implicit val context: ActorRefFactory)
   extends ApiRoute {
-
-  import scorex.core.network.peer.PeerManager.ReceivableMessages.{GetAllPeers, GetConnectedPeers, GetBlacklistedPeers}
-  import scorex.core.network.NetworkController.ReceivableMessages.ConnectTo
 
   override lazy val route: Route = pathPrefix("peers") { allPeers ~ connectedPeers ~ blacklistedPeers ~ connect }
 

--- a/src/main/scala/scorex/core/network/UPnP.scala
+++ b/src/main/scala/scorex/core/network/UPnP.scala
@@ -13,8 +13,8 @@ class UPnP(settings: NetworkSettings) extends ScorexLogging {
 
   private var gateway: Option[GatewayDevice] = None
 
-  lazy val localAddress = gateway.map(_.getLocalAddress)
-  lazy val externalAddress = gateway.map(_.getExternalIPAddress).map(InetAddress.getByName)
+  lazy val localAddress: Option[InetAddress] = gateway.map(_.getLocalAddress)
+  lazy val externalAddress: Option[InetAddress] = gateway.map(_.getExternalIPAddress).map(InetAddress.getByName)
 
   Try {
     log.info("Looking for UPnP gateway device...")


### PR DESCRIPTION
Fixes #224. Re-fixed logic for outgoing connection to peers
(previous fix was incorrect and broke initial peer connections) 

I suggest to delete this pull request in favour of #229