### PR TITLE
Isolate dependency on scorex.crypto to a single file

### DIFF
--- a/examples/src/main/scala/examples/commons/PublicKey25519NoncedBox.scala
+++ b/examples/src/main/scala/examples/commons/PublicKey25519NoncedBox.scala
@@ -6,10 +6,10 @@ import io.circe.syntax._
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.account.PublicKeyNoncedBox
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
-import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.crypto.encode.Base16
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.{Curve25519, PublicKey}
+import scorex.core.utils.ScorexEncoding
+import scorex.core.crypto.encode.Base16
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.{Curve25519, PublicKey}
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
+++ b/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
@@ -14,8 +14,8 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.proof.{Proof, Signature25519}
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.{Curve25519, PublicKey, Signature}
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.{Curve25519, PublicKey, Signature}
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
@@ -14,8 +14,8 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.PrivateKey25519Companion
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding, ScorexLogging}
 import scorex.core.{ModifierTypeId, NodeViewHolder, NodeViewModifier}
-import scorex.crypto.encode.Base58
-import scorex.crypto.signatures.PublicKey
+import scorex.core.crypto.encode.Base58
+import scorex.core.crypto.signatures.PublicKey
 
 
 class HybridNodeViewHolder(settings: ScorexSettings,

--- a/examples/src/main/scala/examples/hybrid/api/http/WalletApiRoute.scala
+++ b/examples/src/main/scala/examples/hybrid/api/http/WalletApiRoute.scala
@@ -12,7 +12,7 @@ import scorex.core.api.http.{ApiError, ApiResponse, ApiRouteWithFullView}
 import scorex.core.settings.RESTApiSettings
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.signatures.PublicKey
+import scorex.core.crypto.signatures.PublicKey
 
 import scala.util.{Failure, Success, Try}
 

--- a/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
+++ b/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
@@ -11,8 +11,8 @@ import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
 import scorex.core.{ModifierId, ModifierTypeId, TransactionsCarryingPersistentNodeViewModifier}
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.{Curve25519, Signature}
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.{Curve25519, Signature}
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/blocks/PowBlock.scala
+++ b/examples/src/main/scala/examples/hybrid/blocks/PowBlock.scala
@@ -11,8 +11,8 @@ import scorex.core.serialization.Serializer
 import scorex.core.transaction.box.proposition.{PublicKey25519Proposition, PublicKey25519PropositionSerializer}
 import scorex.core.utils.ScorexEncoding
 import scorex.core.{ModifierId, _}
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.{Curve25519, PublicKey}
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.{Curve25519, PublicKey}
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/history/HistoryStorage.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HistoryStorage.scala
@@ -8,7 +8,7 @@ import scorex.core.ModifierId
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.consensus.ModifierSemanticValidity.{Absent, Unknown}
 import scorex.core.utils.ScorexLogging
-import scorex.crypto.hash.Sha256
+import scorex.core.crypto.hash.Sha256
 
 import scala.util.{Failure, Random, Try}
 

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -17,7 +17,7 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding, ScorexLogging}
 import scorex.core.validation.RecoverableModifierError
 import scorex.core.{ModifierId, ModifierTypeId, NodeViewModifier}
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/examples/src/main/scala/examples/hybrid/mining/PosForger.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/PosForger.scala
@@ -9,7 +9,7 @@ import examples.hybrid.wallet.HBoxWallet
 import scorex.core.NodeViewHolder.CurrentView
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.ScorexLogging
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 import scorex.utils.Random
 
 

--- a/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
@@ -12,8 +12,8 @@ import scorex.core.NodeViewHolder.CurrentView
 import scorex.core.block.Block.BlockId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.crypto.encode.Base58
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.encode.Base58
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/examples/src/main/scala/examples/hybrid/simulations/PrivateChain.scala
+++ b/examples/src/main/scala/examples/hybrid/simulations/PrivateChain.scala
@@ -11,8 +11,8 @@ import examples.hybrid.wallet.HBoxWallet
 import scorex.core.block.Block.BlockId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding, ScorexLogging}
-import scorex.crypto.encode.Base58
-import scorex.crypto.signatures.PublicKey
+import scorex.core.crypto.encode.Base58
+import scorex.core.crypto.signatures.PublicKey
 
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -11,8 +11,8 @@ import scorex.core.settings.ScorexSettings
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{BoxStateChangeOperation, BoxStateChanges, Insertion, Removal}
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.crypto.authds._
-import scorex.crypto.encode.Base58
+import scorex.core.crypto.authds._
+import scorex.core.crypto.encode.Base58
 import scorex.mid.state.BoxMinimalState
 
 import scala.util.{Failure, Success, Try}

--- a/examples/src/main/scala/examples/hybrid/validation/SemanticBlockValidator.scala
+++ b/examples/src/main/scala/examples/hybrid/validation/SemanticBlockValidator.scala
@@ -2,7 +2,7 @@ package examples.hybrid.validation
 
 import examples.hybrid.blocks.{HybridBlock, PosBlock, PowBlock}
 import scorex.core.block.BlockValidator
-import scorex.crypto.hash.{CryptographicHash, Digest}
+import scorex.core.crypto.hash.{CryptographicHash, Digest}
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/wallet/HBoxWallet.scala
+++ b/examples/src/main/scala/examples/hybrid/wallet/HBoxWallet.scala
@@ -13,7 +13,7 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion, PrivateKey25519Serializer}
 import scorex.core.transaction.wallet.{BoxWallet, BoxWalletTransaction, WalletBox, WalletBoxSerializer}
 import scorex.core.utils.{ByteStr, ScorexEncoding, ScorexLogging}
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/spv/Constants.scala
+++ b/examples/src/main/scala/examples/spv/Constants.scala
@@ -1,6 +1,6 @@
 package examples.spv
 
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 object Constants {
   val hashfn: Blake2b256.type = Blake2b256

--- a/examples/src/main/scala/examples/spv/simulation/SPVSimulator.scala
+++ b/examples/src/main/scala/examples/spv/simulation/SPVSimulator.scala
@@ -3,7 +3,7 @@ package examples.spv.simulation
 import examples.spv.{Header, KMZProofSerializer, SpvAlgos}
 import scorex.core.transaction.state.PrivateKey25519Companion
 import scorex.core.utils.ScorexLogging
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 object SPVSimulator extends App with ScorexLogging with SimulatorFuctions {
 

--- a/examples/src/main/scala/examples/trimchain/core/Algos.scala
+++ b/examples/src/main/scala/examples/trimchain/core/Algos.scala
@@ -11,10 +11,10 @@ import io.iohk.iodb.LSMStore
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{BoxStateChanges, Insertion}
 import scorex.core.{ModifierId, VersionTag}
-import scorex.crypto.authds.avltree.batch.{BatchAVLVerifier, Lookup}
-import scorex.crypto.authds.{ADDigest, ADKey}
-import scorex.crypto.hash.{Blake2b256, Digest32}
-import scorex.crypto.signatures.{Curve25519, PublicKey}
+import scorex.core.crypto.authds.avltree.batch.{BatchAVLVerifier, Lookup}
+import scorex.core.crypto.authds.{ADDigest, ADKey}
+import scorex.core.crypto.hash.{Blake2b256, Digest32}
+import scorex.core.crypto.signatures.{Curve25519, PublicKey}
 
 import scala.util.{Failure, Random, Success, Try}
 
@@ -90,7 +90,7 @@ object Algos extends App {
       val ids = (0 until NElementsInProof) map (elementIndex => hashfn(seed ++ minerKey ++
         Ints.toByteArray(stateIndex) ++ Ints.toByteArray(elementIndex)))
 
-      val v = new BatchAVLVerifier[Digest32, Blake2b256.type](ADDigest @@ sroot, pp, keyLength = BoxKeyLength,
+      val v = new BatchAVLVerifier[Digest32, scorex.crypto.hash.Blake2b256.type](ADDigest @@ sroot, pp, keyLength = BoxKeyLength,
         valueLengthOpt = Some(BoxLength))
 
       ids.foreach(id => v.performOneOperation(Lookup(ADKey @@ id)).get)

--- a/examples/src/main/scala/examples/trimchain/core/Constants.scala
+++ b/examples/src/main/scala/examples/trimchain/core/Constants.scala
@@ -1,6 +1,6 @@
 package examples.trimchain.core
 
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 
 object Constants {

--- a/examples/src/main/scala/examples/trimchain/core/Ticket.scala
+++ b/examples/src/main/scala/examples/trimchain/core/Ticket.scala
@@ -5,8 +5,8 @@ import io.circe.Encoder
 import io.circe.syntax._
 import scorex.core.serialization.Serializer
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.authds.SerializedAdProof
-import scorex.crypto.signatures.Curve25519
+import scorex.core.crypto.authds.SerializedAdProof
+import scorex.core.crypto.signatures.Curve25519
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/trimchain/simulation/InMemoryAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/simulation/InMemoryAuthenticatedUtxo.scala
@@ -8,8 +8,8 @@ import scorex.core.VersionTag
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{BoxStateChanges, Insertion, Removal}
 import scorex.core.utils.ScorexLogging
-import scorex.crypto.authds.avltree.batch.{Insert, Remove}
-import scorex.crypto.authds.{ADKey, ADValue}
+import scorex.core.crypto.authds.avltree.batch.{Insert, Remove}
+import scorex.core.crypto.authds.{ADKey, ADValue}
 import scorex.mid.state.BoxMinimalState
 
 import scala.util.Try

--- a/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
+++ b/examples/src/main/scala/examples/trimchain/utxo/PersistentAuthenticatedUtxo.scala
@@ -11,10 +11,10 @@ import scorex.core.settings.ScorexSettings
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{BoxStateChangeOperation, BoxStateChanges, Insertion, Removal}
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.crypto.authds.avltree.batch.{BatchAVLProver, Insert, Lookup, Remove}
-import scorex.crypto.authds.{ADKey, ADValue, SerializedAdProof}
-import scorex.crypto.encode.Base58
-import scorex.crypto.hash.{Blake2b256, Digest32}
+import scorex.core.crypto.authds.avltree.batch.{BatchAVLProver, Insert, Lookup, Remove}
+import scorex.core.crypto.authds.{ADKey, ADValue, SerializedAdProof}
+import scorex.core.crypto.encode.Base58
+import scorex.core.crypto.hash.{Blake2b256, Digest32}
 import scorex.mid.state.BoxMinimalState
 
 import scala.util.{Random, Success, Try}
@@ -162,7 +162,7 @@ case class PersistentAuthenticatedUtxo(store: LSMStore,
 
 object PersistentAuthenticatedUtxo {
 
-  type ProverType = BatchAVLProver[Digest32, Blake2b256.type]
+  type ProverType = BatchAVLProver[Digest32, scorex.crypto.hash.Blake2b256.type]
 
   def semanticValidity(tx: SimpleBoxTransaction): Try[Unit] = Try {
     require(tx.from.size == tx.signatures.size)

--- a/examples/src/test/scala/hybrid/HistoryGenerators.scala
+++ b/examples/src/test/scala/hybrid/HistoryGenerators.scala
@@ -6,7 +6,7 @@ import examples.hybrid.mining.HybridSettings
 import org.scalacheck.Gen
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.NetworkTimeProvider
-import scorex.crypto.signatures.PublicKey
+import scorex.core.crypto.signatures.PublicKey
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/examples/src/test/scala/hybrid/HybridGenerators.scala
+++ b/examples/src/test/scala/hybrid/HybridGenerators.scala
@@ -15,8 +15,8 @@ import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state._
 import scorex.core.transaction.wallet.WalletBox
 import scorex.core.{ModifierId, NodeViewModifier}
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.Signature
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.Signature
 import scorex.testkit.utils.{FileUtils, NoShrink}
 
 import scala.collection.concurrent.TrieMap

--- a/examples/src/test/scala/hybrid/ModifierGenerators.scala
+++ b/examples/src/test/scala/hybrid/ModifierGenerators.scala
@@ -9,7 +9,7 @@ import org.scalacheck.Gen
 import scorex.core.ModifierId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.PrivateKey25519
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 import scorex.testkit.generators.{CoreGenerators, ModifierProducerTemplateItem, SynInvalid, Valid}
 
 import scala.collection.mutable

--- a/examples/src/test/scala/hybrid/state/SimpleBoxTransactionSpecification.scala
+++ b/examples/src/test/scala/hybrid/state/SimpleBoxTransactionSpecification.scala
@@ -8,9 +8,9 @@ import org.scalatest.{Matchers, PropSpec}
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state.PrivateKey25519Companion
-import scorex.crypto.encode.Base58
-import scorex.crypto.hash.Sha256
-import scorex.crypto.signatures.{PublicKey, Signature}
+import scorex.core.crypto.encode.Base58
+import scorex.core.crypto.hash.Sha256
+import scorex.core.crypto.signatures.{PublicKey, Signature}
 
 @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class SimpleBoxTransactionSpecification extends PropSpec

--- a/examples/src/test/scala/hybrid/validation/SemanticBlockValidatorSpecification.scala
+++ b/examples/src/test/scala/hybrid/validation/SemanticBlockValidatorSpecification.scala
@@ -4,7 +4,7 @@ import examples.hybrid.validation.SemanticBlockValidator
 import hybrid.HybridGenerators
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 
 class SemanticBlockValidatorSpecification extends PropSpec

--- a/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
+++ b/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
@@ -11,7 +11,7 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.ByteStr
-import scorex.crypto.signatures.Signature
+import scorex.core.crypto.signatures.Signature
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/examples/src/test/scala/spv/ChainTests.scala
+++ b/examples/src/test/scala/spv/ChainTests.scala
@@ -8,8 +8,8 @@ import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
-import scorex.crypto.hash
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.util.{Failure, Try}
 

--- a/examples/src/test/scala/trimchain/TrimchainGenerators.scala
+++ b/examples/src/test/scala/trimchain/TrimchainGenerators.scala
@@ -6,7 +6,7 @@ import examples.trimchain.core._
 import examples.trimchain.modifiers.{BlockHeader, TBlock}
 import org.scalacheck.{Arbitrary, Gen}
 import scorex.core.ModifierId
-import scorex.crypto.authds.SerializedAdProof
+import scorex.core.crypto.authds.SerializedAdProof
 
 trait TrimchainGenerators extends ExamplesCommonGenerators {
 

--- a/src/main/scala/scorex/ObjectGenerators.scala
+++ b/src/main/scala/scorex/ObjectGenerators.scala
@@ -8,7 +8,7 @@ import scorex.core.network.message.BasicMsgDataTypes._
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
 import scorex.core.{ModifierId, ModifierTypeId, NodeViewModifier}
-import scorex.crypto.signatures.Curve25519
+import scorex.core.crypto.signatures.Curve25519
 
 trait ObjectGenerators {
 

--- a/src/main/scala/scorex/core/api/http/ApiDirectives.scala
+++ b/src/main/scala/scorex/core/api/http/ApiDirectives.scala
@@ -3,7 +3,7 @@ package scorex.core.api.http
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive0, Directives}
 import scorex.core.settings.RESTApiSettings
-import scorex.crypto.hash.{Blake2b256, Digest}
+import scorex.core.crypto.hash.{Blake2b256, Digest}
 
 trait ApiDirectives extends Directives {
   val settings: RESTApiSettings

--- a/src/main/scala/scorex/core/api/http/UtilsApiRoute.scala
+++ b/src/main/scala/scorex/core/api/http/UtilsApiRoute.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server.Route
 import io.circe.Json
 import scorex.core.settings.RESTApiSettings
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 
 case class UtilsApiRoute(override val settings: RESTApiSettings)(implicit val context: ActorRefFactory)

--- a/src/main/scala/scorex/core/consensus/History.scala
+++ b/src/main/scala/scorex/core/consensus/History.scala
@@ -2,7 +2,7 @@ package scorex.core.consensus
 
 import scorex.core._
 import scorex.core.consensus.History.ProgressInfo
-import scorex.crypto.encode.BytesEncoder
+import scorex.core.crypto.encode.BytesEncoder
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/core.scala
+++ b/src/main/scala/scorex/core/core.scala
@@ -1,7 +1,7 @@
 package scorex
 
 import scorex.core.network.message.BasicMsgDataTypes.InvData
-import scorex.crypto.encode.BytesEncoder
+import scorex.core.crypto.encode.BytesEncoder
 import supertagged.TaggedType
 
 package object core {

--- a/src/main/scala/scorex/core/crypto/package.scala
+++ b/src/main/scala/scorex/core/crypto/package.scala
@@ -1,0 +1,64 @@
+package scorex.core
+
+// The purpose of this package is to act as a single interface
+// between scorex.core and scorex.crypto.
+//
+// This is the only file in scorex.core that directly depends
+// on scorex.crypto
+
+package object crypto {
+  import scorex.crypto.{ hash => h }
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object hash {
+    val Blake2b256 = h.Blake2b256
+    type Blake2b256 = h.Blake2b256.type
+    type Digest = h.Digest
+
+    val Sha256 = h.Sha256 // only used in Examples
+    type CryptographicHash[D <: Digest] = h.CryptographicHash[D] // only used in Examples
+    type Digest32 = h.Digest32 // only used in Examples
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object signatures {
+    import scorex.crypto.{ signatures => s }
+    val Curve25519 = s.Curve25519
+    val PublicKey = s.PublicKey
+    type PublicKey = s.PublicKey
+    val PrivateKey = s.PrivateKey
+    type PrivateKey = s.PrivateKey
+    val Signature = s.Signature
+    type Signature = s.Signature
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object encode {
+    import scorex.crypto.{ encode => e }
+    val Base16 = e.Base16
+    val Base58 = e.Base58
+    type BytesEncoder = e.BytesEncoder
+  }
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  object authds {
+    import scorex.crypto.{ authds => a }
+    val ADKey = a.ADKey
+    type ADKey = a.ADKey
+
+    val ADValue = a.ADValue // Only used in Examples
+    type ADValue = a.ADValue // Only used in Examples
+    val SerializedAdProof = a.SerializedAdProof // Only used in Examples
+    type SerializedAdProof = a.SerializedAdProof // Only used in Examples
+    val ADDigest = a.ADDigest // Only used in Examples
+    type ADDigest = a.ADDigest // Only used in Examples
+
+    object avltree { // Only used in Examples
+      object batch {
+        import a.avltree.{ batch => b }
+        type BatchAVLVerifier[D <: h.Digest, HF <: h.CryptographicHash[D]] = b.BatchAVLVerifier[D, HF]
+        type BatchAVLProver[D <: h.Digest, HF <: h.CryptographicHash[D]] = b.BatchAVLProver[D, HF]
+        val Insert = b.Insert
+        val Lookup = b.Lookup
+        val Remove = b.Remove
+      }
+    }
+  }
+}

--- a/src/main/scala/scorex/core/network/message/Message.scala
+++ b/src/main/scala/scorex/core/network/message/Message.scala
@@ -3,7 +3,7 @@ package scorex.core.network.message
 import com.google.common.primitives.{Bytes, Ints}
 import scorex.core.network.ConnectedPeer
 import scorex.core.serialization.{BytesSerializable, Serializer}
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.util.{Success, Try}
 

--- a/src/main/scala/scorex/core/network/message/MessageHandler.scala
+++ b/src/main/scala/scorex/core/network/message/MessageHandler.scala
@@ -3,7 +3,7 @@ package scorex.core.network.message
 import java.nio.ByteBuffer
 
 import scorex.core.network.ConnectedPeer
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 import scala.language.existentials
 import scala.util.Try

--- a/src/main/scala/scorex/core/transaction/Transaction.scala
+++ b/src/main/scala/scorex/core/transaction/Transaction.scala
@@ -1,7 +1,7 @@
 package scorex.core.transaction
 
 import scorex.core.{EphemerealNodeViewModifier, ModifierId, ModifierTypeId}
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.hash.Blake2b256
 
 
 /**

--- a/src/main/scala/scorex/core/transaction/account/PublicKeyNoncedBox.scala
+++ b/src/main/scala/scorex/core/transaction/account/PublicKeyNoncedBox.scala
@@ -4,8 +4,8 @@ import com.google.common.primitives.Longs
 import scorex.core.ModifierId
 import scorex.core.transaction.box.Box
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
-import scorex.crypto.authds._
-import scorex.crypto.hash.Blake2b256
+import scorex.core.crypto.authds._
+import scorex.core.crypto.hash.Blake2b256
 
 trait PublicKeyNoncedBox[PKP <: PublicKey25519Proposition] extends Box[PKP] {
   val nonce: Long

--- a/src/main/scala/scorex/core/transaction/box/Box.scala
+++ b/src/main/scala/scorex/core/transaction/box/Box.scala
@@ -2,7 +2,7 @@ package scorex.core.transaction.box
 
 import scorex.core.serialization.BytesSerializable
 import scorex.core.transaction.box.proposition.Proposition
-import scorex.crypto.authds._
+import scorex.core.crypto.authds._
 
 /**
   * Box is a state element locked by some proposition.

--- a/src/main/scala/scorex/core/transaction/box/proposition/PublicKey25519Proposition.scala
+++ b/src/main/scala/scorex/core/transaction/box/proposition/PublicKey25519Proposition.scala
@@ -3,8 +3,8 @@ package scorex.core.transaction.box.proposition
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.hash.Blake2b256
-import scorex.crypto.signatures.{Curve25519, PublicKey, Signature}
+import scorex.core.crypto.hash.Blake2b256
+import scorex.core.crypto.signatures.{Curve25519, PublicKey, Signature}
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/scorex/core/transaction/proof/Signature25519.scala
+++ b/src/main/scala/scorex/core/transaction/proof/Signature25519.scala
@@ -4,7 +4,7 @@ import scorex.core.serialization.Serializer
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.signatures.{Curve25519, Signature}
+import scorex.core.crypto.signatures.{Curve25519, Signature}
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/transaction/state/BoxStateChanges.scala
+++ b/src/main/scala/scorex/core/transaction/state/BoxStateChanges.scala
@@ -3,7 +3,7 @@ package scorex.core.transaction.state
 import scorex.core.transaction.box.Box
 import scorex.core.transaction.box.proposition.Proposition
 import scorex.core.utils.ScorexEncoding
-import scorex.crypto.authds._
+import scorex.core.crypto.authds._
 
 abstract class BoxStateChangeOperation[P <: Proposition, BX <: Box[P]]
 

--- a/src/main/scala/scorex/core/transaction/state/SecretHolder.scala
+++ b/src/main/scala/scorex/core/transaction/state/SecretHolder.scala
@@ -5,7 +5,7 @@ import scorex.core.serialization.{BytesSerializable, Serializer}
 import scorex.core.transaction.box._
 import scorex.core.transaction.box.proposition.{ProofOfKnowledgeProposition, PublicKey25519Proposition}
 import scorex.core.transaction.proof.{ProofOfKnowledge, Signature25519}
-import scorex.crypto.signatures.{Curve25519, PrivateKey, PublicKey}
+import scorex.core.crypto.signatures.{Curve25519, PrivateKey, PublicKey}
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/utils/ByteStr.scala
+++ b/src/main/scala/scorex/core/utils/ByteStr.scala
@@ -1,6 +1,6 @@
 package scorex.core.utils
 
-import scorex.crypto.encode.{Base16, Base58}
+import scorex.core.crypto.encode.{Base16, Base58}
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/utils/ScorexEncoding.scala
+++ b/src/main/scala/scorex/core/utils/ScorexEncoding.scala
@@ -1,6 +1,6 @@
 package scorex.core.utils
 
-import scorex.crypto.encode.{Base16, BytesEncoder}
+import scorex.core.crypto.encode.{Base16, BytesEncoder}
 
 /**
   * Trait with bytes to string encoder

--- a/src/main/scala/scorex/core/utils/ScorexLogging.scala
+++ b/src/main/scala/scorex/core/utils/ScorexLogging.scala
@@ -1,7 +1,7 @@
 package scorex.core.utils
 
 import com.typesafe.scalalogging.StrictLogging
-import scorex.crypto.encode.{Base16, BytesEncoder}
+import scorex.core.crypto.encode.{Base16, BytesEncoder}
 
 /**
 * TODO extract to ScorexUtils project

--- a/src/main/scala/scorex/core/validation/ModifierValidator.scala
+++ b/src/main/scala/scorex/core/validation/ModifierValidator.scala
@@ -4,7 +4,7 @@ package scorex.core.validation
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.utils.ScorexLogging
 import scorex.core.validation.ValidationResult._
-import scorex.crypto.encode.{Base58, BytesEncoder}
+import scorex.core.crypto.encode.{Base58, BytesEncoder}
 
 /** Base trait for the modifier validation process.
   *

--- a/src/test/scala/scorex/core/validation/ValidationSpec.scala
+++ b/src/test/scala/scorex/core/validation/ValidationSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scorex.core.ModifierId
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.validation.ValidationResult._
-import scorex.crypto.encode.{Base16, BytesEncoder}
+import scorex.core.crypto.encode.{Base16, BytesEncoder}
 
 class ValidationSpec extends FlatSpec with Matchers with ModifierValidator {
 


### PR DESCRIPTION
Before this PR, many files in scorex.core depended on scorex.crypto.  This PR creates a file that serves as interface to scorex.crypto. All other files now only depend on this new file. And this new file is the only file that depends on scorex.crypto.

This PR will ease the replacement of `Array[Byte]` by `ByteString` in #221.