### PR TITLE
Reworked DeliveryTracker(and fix for #266)

### DIFF
--- a/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
+++ b/examples/src/main/scala/examples/hybrid/HybridNodeViewHolder.scala
@@ -23,8 +23,6 @@ class HybridNodeViewHolder(settings: ScorexSettings,
                            timeProvider: NetworkTimeProvider)
   extends NodeViewHolder[SimpleBoxTransaction, HybridBlock] {
 
-  override val networkChunkSize: Int = settings.network.networkChunkSize
-
   override type SI = HybridSyncInfo
 
   override type HIS = HybridHistory

--- a/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
+++ b/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
@@ -84,8 +84,8 @@ class HybridHistorySpecification extends PropSpec
 
   }
 
-  def compareAndCheck(history: HybridHistory, syncInfo: HybridSyncInfo, networkChunkSize: Int = 10): HistoryComparisonResult = {
-    val extensionOpt = history.continuationIds(syncInfo.startingPoints, networkChunkSize)
+  def compareAndCheck(history: HybridHistory, syncInfo: HybridSyncInfo, continuationSize: Int = 10): HistoryComparisonResult = {
+    val extensionOpt = history.continuationIds(syncInfo.startingPoints, continuationSize)
     val comparison = history.compare(syncInfo)
     if (comparison == Younger) {
       println(extensionOpt)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -73,8 +73,6 @@ scorex {
     # Add delay for sending message
     # addedMaxDelay = 0ms
 
-    networkChunkSize = 10
-
     # Accept only local connections
     localOnly = false
 

--- a/src/main/scala/scorex/core/NodeViewHolder.scala
+++ b/src/main/scala/scorex/core/NodeViewHolder.scala
@@ -77,13 +77,6 @@ trait NodeViewHolder[TX <: Transaction, PMOD <: PersistentNodeViewModifier]
     */
   val modifierSerializers: Map[ModifierTypeId, Serializer[_ <: NodeViewModifier]]
 
-  //todo: write desc
-  /**
-    *
-    */
-  val networkChunkSize: Int
-
-
   protected type MapKey = scala.collection.mutable.WrappedArray.ofByte
 
   protected def key(id: ModifierId): MapKey = new mutable.WrappedArray.ofByte(id)

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -140,7 +140,7 @@ MR <: MempoolReader[TX]](networkControllerRef: ActorRef,
 
       historyReaderOpt match {
         case Some(historyReader) =>
-          val extensionOpt = historyReader.continuationIds(syncInfo, networkSettings.networkChunkSize)
+          val extensionOpt = historyReader.continuationIds(syncInfo, networkSettings.maxInvObjects)
           val ext = extensionOpt.getOrElse(Seq())
           val comparison = historyReader.compare(syncInfo)
           log.debug(s"Comparison with $remote having starting points ${idsToString(syncInfo.startingPoints)}. " +

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -263,7 +263,6 @@ MR <: MempoolReader[TX]](networkControllerRef: ActorRef,
   @SuppressWarnings(Array("org.wartremover.warts.JavaSerializable"))
   protected def checkDelivery: Receive = {
     case CheckDelivery(peer, modifierTypeId, modifierId) =>
-
       if (deliveryTracker.peerWhoDelivered(modifierId).contains(peer)) {
         deliveryTracker.delete(modifierId)
       } else {

--- a/src/main/scala/scorex/core/settings/Settings.scala
+++ b/src/main/scala/scorex/core/settings/Settings.scala
@@ -17,7 +17,6 @@ case class RESTApiSettings(bindAddress: InetSocketAddress,
 
 case class NetworkSettings(nodeName: String,
                            addedMaxDelay: Option[FiniteDuration],
-                           networkChunkSize: Int,
                            localOnly: Boolean,
                            knownPeers: Seq[InetSocketAddress],
                            bindAddress: InetSocketAddress,

--- a/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
+++ b/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
@@ -23,7 +23,7 @@ class DeliveryTrackerSpecification extends PropSpec
   with Matchers
   with ObjectGenerators {
 
-  property("expect, onReceive, isExpecting") {
+  property("basic ops") {
     implicit val system = ActorSystem()
     val probe = TestProbe("p")(system)
     implicit val nvsStub: ActorRef = probe.testActor
@@ -42,13 +42,13 @@ class DeliveryTrackerSpecification extends PropSpec
 
     tracker.expect(cp, mtid, modids)
 
-    tracker.isExpecting(mtid, modids.head, cp) shouldBe true
+    tracker.isExpecting(modids.head) shouldBe true
 
-    tracker.isExpecting(mtid, notAdded, cp) shouldBe false
+    tracker.isExpecting(notAdded) shouldBe false
 
     tracker.onReceive(mtid, modids.head, cp)
 
-    tracker.isExpecting(mtid, modids.head, cp) shouldBe false
+    tracker.isExpecting(modids.head) shouldBe false
 
     tracker.peerWhoDelivered(modids.head).get shouldBe cp
 
@@ -57,15 +57,15 @@ class DeliveryTrackerSpecification extends PropSpec
     tracker.isSpam(notAdded) shouldBe true
 
     tracker.reexpect(cp, mtid, modids(1))
-    tracker.isExpecting(mtid, modids(1), cp) shouldBe true
+    tracker.isExpecting(modids(1)) shouldBe true
 
     tracker.reexpect(cp, mtid, modids(1))
-    tracker.isExpecting(mtid, modids(1), cp) shouldBe false
+    tracker.isExpecting(modids(1)) shouldBe false
 
     tracker.reexpect(cp, mtid, modids(1))
-    tracker.isExpecting(mtid, modids(1), cp) shouldBe true
+    tracker.isExpecting(modids(1)) shouldBe true
 
-    //tracker.reexpect(cp, mtid, modids.head)
-    //tracker.isExpecting(mtid, modids.head, cp) shouldBe true
+    tracker.reexpect(cp, mtid, modids.head)
+    tracker.isExpecting(modids.head) shouldBe true
   }
 }

--- a/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
+++ b/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
@@ -1,0 +1,71 @@
+package scorex.core.network
+
+import java.net.InetSocketAddress
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.TestProbe
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
+import scorex.ObjectGenerators
+import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.crypto.hash.Blake2b256
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@SuppressWarnings(Array(
+  "org.wartremover.warts.Null",
+  "org.wartremover.warts.TraversableOps",
+  "org.wartremover.warts.OptionPartial"))
+class DeliveryTrackerSpecification extends PropSpec
+  with PropertyChecks
+  with GeneratorDrivenPropertyChecks
+  with Matchers
+  with ObjectGenerators {
+
+  property("expect, onReceive, isExpecting") {
+    implicit val system = ActorSystem()
+    val probe = TestProbe("p")(system)
+    implicit val nvsStub: ActorRef = probe.testActor
+
+    val dt = FiniteDuration(3, MINUTES)
+
+    val tracker = new DeliveryTracker(system, deliveryTimeout = dt, maxDeliveryChecks = 2, nvsStub)
+
+    val cp = ConnectedPeer(new InetSocketAddress(55), null, null, null)
+
+    val mtid = ModifierTypeId @@ (0: Byte)
+
+    val modids = Seq(Blake2b256("1"), Blake2b256("2"), Blake2b256("3")).map(ModifierId @@ _)
+
+    val notAdded = ModifierId @@ Blake2b256("4")
+
+    tracker.expect(cp, mtid, modids)
+
+    tracker.isExpecting(mtid, modids.head, cp) shouldBe true
+
+    tracker.isExpecting(mtid, notAdded, cp) shouldBe false
+
+    tracker.onReceive(mtid, modids.head, cp)
+
+    tracker.isExpecting(mtid, modids.head, cp) shouldBe false
+
+    tracker.peerWhoDelivered(modids.head).get shouldBe cp
+
+
+    tracker.onReceive(mtid, notAdded, cp)
+    tracker.isSpam(notAdded) shouldBe true
+
+    tracker.reexpect(cp, mtid, modids(1))
+    tracker.isExpecting(mtid, modids(1), cp) shouldBe true
+
+    tracker.reexpect(cp, mtid, modids(1))
+    tracker.isExpecting(mtid, modids(1), cp) shouldBe false
+
+    tracker.reexpect(cp, mtid, modids(1))
+    tracker.isExpecting(mtid, modids(1), cp) shouldBe true
+
+    //tracker.reexpect(cp, mtid, modids.head)
+    //tracker.isExpecting(mtid, modids.head, cp) shouldBe true
+  }
+}


### PR DESCRIPTION
DeliveryTracker has been reworked, and DeliveryTrackerSpecification has been implemented. 

However, an interaction between NodeViewSynchronizer and DeliveryTracker is not ideal and probably error-prone. That could be fixed in another PR after considerations. 