### PR TITLE
Fix for #288: generated Modifiers message could not be more than maxPacketSize

### DIFF
--- a/src/main/scala/scorex/core/app/Application.scala
+++ b/src/main/scala/scorex/core/app/Application.scala
@@ -45,12 +45,13 @@ trait Application extends ScorexLogging {
   private lazy val basicSpecs = {
     val invSpec = new InvSpec(settings.network.maxInvObjects)
     val requestModifierSpec = new RequestModifierSpec(settings.network.maxInvObjects)
+    val modifiersSpec = new ModifiersSpec(settings.network.maxPacketSize)
     Seq(
       GetPeersSpec,
       PeersSpec,
       invSpec,
       requestModifierSpec,
-      ModifiersSpec
+      modifiersSpec
     )
   }
 

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -87,7 +87,7 @@ object ModifiersSpec {
   val MessageCode: MessageCode = 33: Byte
   val MessageName: String = "Modifier"
 }
-class ModifiersSpec(maxPacketSize: Int) extends MessageSpec[ModifiersData] {
+class ModifiersSpec(maxMessageSize: Int) extends MessageSpec[ModifiersData] {
   import ModifiersSpec._
 
   override val messageCode: MessageCode = MessageCode
@@ -117,7 +117,7 @@ class ModifiersSpec(maxPacketSize: Int) extends MessageSpec[ModifiersData] {
     var msgSize = 5
     val payload: Seq[Array[Byte]] = modifiers.flatMap {case (id, modifier) =>
       msgSize += id.length + 4 + modifier.length
-      if(msgSize < maxPacketSize) Seq(id, Ints.toByteArray(modifier.length), modifier) else Seq()
+      if(msgSize < maxMessageSize) Seq(id, Ints.toByteArray(modifier.length), modifier) else Seq()
     }.toSeq
 
     scorex.core.utils.concatBytes(Seq(Array(typeId), Ints.toByteArray(payload.size / 3)) ++ payload)

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -34,7 +34,9 @@ object InvSpec {
   val MessageCode: Byte = 55
   val MessageName: String = "Inv"
 }
+
 class InvSpec(maxInvObjects: Int) extends MessageSpec[InvData] {
+
   import InvSpec._
 
   override val messageCode = MessageCode
@@ -67,8 +69,10 @@ object RequestModifierSpec {
   val MessageCode: MessageCode = 22: Byte
   val MessageName: String = "RequestModifier"
 }
+
 class RequestModifierSpec(maxInvObjects: Int)
   extends MessageSpec[InvData] {
+
   import RequestModifierSpec._
 
   override val messageCode: MessageCode = MessageCode
@@ -88,7 +92,9 @@ object ModifiersSpec {
   val MessageCode: MessageCode = 33: Byte
   val MessageName: String = "Modifier"
 }
+
 class ModifiersSpec(maxMessageSize: Int) extends MessageSpec[ModifiersData] with ScorexLogging {
+
   import ModifiersSpec._
 
   override val messageCode: MessageCode = MessageCode
@@ -116,12 +122,12 @@ class ModifiersSpec(maxMessageSize: Int) extends MessageSpec[ModifiersData] with
     val modifiers = data._2
 
     var msgSize = 5
-    val payload: Seq[Array[Byte]] = modifiers.flatMap {case (id, modifier) =>
+    val payload: Seq[Array[Byte]] = modifiers.flatMap { case (id, modifier) =>
       msgSize += id.length + 4 + modifier.length
-      if(msgSize <= maxMessageSize) Seq(id, Ints.toByteArray(modifier.length), modifier) else Seq()
+      if (msgSize <= maxMessageSize) Seq(id, Ints.toByteArray(modifier.length), modifier) else Seq()
     }.toSeq
 
-    if(msgSize > maxMessageSize){
+    if (msgSize > maxMessageSize) {
       log.info(s"Modifiers message of $msgSize generated while the maximum is $maxMessageSize. Better to fix app layer.")
     }
 

--- a/src/test/scala/scorex/network/MessageSpecification.scala
+++ b/src/test/scala/scorex/network/MessageSpecification.scala
@@ -79,6 +79,14 @@ class MessageSpecification extends PropSpec
         }
 
         modifiersSpec.toBytes(data) shouldEqual bytes
+
+        val modifiersSpecLimited = new ModifiersSpec(6)
+        val bytes2 = modifiersSpecLimited.toBytes(data)
+        val recovered2 = modifiersSpecLimited.parseBytes(bytes2).get
+
+        recovered2._1 shouldEqual data._1
+        (recovered2._2.keys.size == data._2.keys.size) shouldEqual false
+        recovered2._2.keys.size shouldEqual 0
       }
     }
   }

--- a/src/test/scala/scorex/network/MessageSpecification.scala
+++ b/src/test/scala/scorex/network/MessageSpecification.scala
@@ -62,8 +62,10 @@ class MessageSpecification extends PropSpec
   property("ModifiersSpec serialization/deserialization") {
     forAll(modifiersGen) { data: (ModifierTypeId, Map[ModifierId, Array[Byte]]) =>
       whenever(data._2.nonEmpty && data._2.forall { case (id, m) => id.length == NodeViewModifier.ModifierIdSize && m.length > 0 }) {
-        val bytes = ModifiersSpec.toBytes(data)
-        val recovered = ModifiersSpec.parseBytes(bytes).get
+        val modifiersSpec = new ModifiersSpec(1024 * 1024)
+
+        val bytes = modifiersSpec.toBytes(data)
+        val recovered = modifiersSpec.parseBytes(bytes).get
 
         recovered._1 shouldEqual data._1
         recovered._2.keys.size shouldEqual data._2.keys.size
@@ -76,7 +78,7 @@ class MessageSpecification extends PropSpec
           data._2.values.toSet.exists(_.sameElements(v)) shouldEqual true
         }
 
-        ModifiersSpec.toBytes(data) shouldEqual bytes
+        modifiersSpec.toBytes(data) shouldEqual bytes
       }
     }
   }

--- a/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
+++ b/testkit/src/main/scala/scorex/testkit/properties/NodeViewSynchronizerTests.scala
@@ -191,7 +191,10 @@ trait NodeViewSynchronizerTests[
 
   ignore("NodeViewSynchronizer: DataFromPeer: Non-Asked Modifiers from Remote") { withFixture { ctx =>
     import ctx._
-    node ! DataFromPeer(ModifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer)
+
+    val modifiersSpec = new ModifiersSpec(1024 * 1024)
+
+    node ! DataFromPeer(modifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer)
     val messages = vhProbe.receiveWhile(max = 3 seconds, idle = 1 second) {
       case m => m
     }
@@ -204,8 +207,11 @@ trait NodeViewSynchronizerTests[
 
   property("NodeViewSynchronizer: DataFromPeer: Asked Modifiers from Remote") { withFixture { ctx =>
     import ctx._
+
+    val modifiersSpec = new ModifiersSpec(1024 * 1024)
+
     node ! RequestFromLocal(peer, mod.modifierTypeId, Seq(mod.id))
-    node ! DataFromPeer(ModifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer)
+    node ! DataFromPeer(modifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer)
     vhProbe.fishForMessage(3 seconds) { case m =>
       m == ModifiersFromRemote(peer, mod.modifierTypeId, Seq(mod.bytes))
     }
@@ -225,9 +231,12 @@ trait NodeViewSynchronizerTests[
 
   property("NodeViewSynchronizer: RequestFromLocal - CheckDelivery -  Do not penalize if delivered") { withFixture { ctx =>
     import ctx._
+
+    val modifiersSpec = new ModifiersSpec(1024 * 1024)
+
     node ! RequestFromLocal(peer, mod.modifierTypeId, Seq(mod.id))
     import scala.concurrent.ExecutionContext.Implicits.global
-    system.scheduler.scheduleOnce(1 second, node, DataFromPeer(ModifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer) )
+    system.scheduler.scheduleOnce(1 second, node, DataFromPeer(modifiersSpec, (mod.modifierTypeId, Map(mod.id -> mod.bytes)), peer) )
     val messages = ncProbe.receiveWhile(max = 5 seconds, idle = 1 second) { case m => m }
     assert(!messages.contains(Blacklist(peer)))
   }}


### PR DESCRIPTION
From now, generated Modifiers message could not be more than maxPacketSize. A test ModifiersSpec has been enhanced to reflect this change.