### PR TITLE
Move ModifierId to scorex-util (with Base* encoders moved from scrypto)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,8 @@ val testingDependencies = Seq(
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.2",
-  "org.scorexfoundation" %% "scrypto" % "2.+"
+  "org.scorexfoundation" %% "scrypto" % "2.+",
+  "org.scorexfoundation" %% "scorex-util" % "0.1.1-SNAPSHOT"
 ) ++ networkDependencies ++ apiDependencies ++ loggingDependencies ++ testingDependencies
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ val testingDependencies = Seq(
 
 libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.2",
-  "org.scorexfoundation" %% "scrypto" % "2.+",
+  "org.scorexfoundation" %% "scrypto" % "2.1.3-SNAPSHOT",
   "org.scorexfoundation" %% "scorex-util" % "0.1.1-SNAPSHOT"
 ) ++ networkDependencies ++ apiDependencies ++ loggingDependencies ++ testingDependencies
 

--- a/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
+++ b/examples/src/main/scala/examples/commons/SimpleBoxTransaction.scala
@@ -5,7 +5,6 @@ import examples.hybrid.wallet.HBoxWallet
 import io.circe.Encoder
 import io.circe.syntax._
 import io.iohk.iodb.ByteArrayWrapper
-import scorex.core.ModifierId
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.BoxTransaction
 import scorex.core.transaction.account.PublicKeyNoncedBox

--- a/examples/src/main/scala/examples/commons/SimpleBoxTransactionMemPool.scala
+++ b/examples/src/main/scala/examples/commons/SimpleBoxTransactionMemPool.scala
@@ -1,9 +1,9 @@
 package examples.commons
 
 import io.iohk.iodb.ByteArrayWrapper
-import scorex.core.ModifierId
 import scorex.core.transaction.MemoryPool
 import scorex.core.utils.ScorexLogging
+import scorex.util.ModifierId
 
 import scala.collection.concurrent.TrieMap
 import scala.util.{Success, Try}

--- a/examples/src/main/scala/examples/commons/curvepos.scala
+++ b/examples/src/main/scala/examples/commons/curvepos.scala
@@ -2,6 +2,7 @@ package examples
 
 import io.iohk.iodb.ByteArrayWrapper
 import scorex.core._
+import scorex.util._
 import supertagged.TaggedType
 
 package object commons {

--- a/examples/src/main/scala/examples/hybrid/api/http/DebugApiRoute.scala
+++ b/examples/src/main/scala/examples/hybrid/api/http/DebugApiRoute.scala
@@ -8,10 +8,10 @@ import examples.hybrid.history.HybridHistory
 import examples.hybrid.state.HBoxStoredState
 import examples.hybrid.wallet.HBoxWallet
 import io.circe.syntax._
-import scorex.core.bytesToId
 import scorex.core.api.http.{ApiResponse, ApiRouteWithFullView}
 import scorex.core.settings.RESTApiSettings
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/api/http/StatsApiRoute.scala
+++ b/examples/src/main/scala/examples/hybrid/api/http/StatsApiRoute.scala
@@ -7,10 +7,10 @@ import examples.hybrid.history.HybridHistory
 import examples.hybrid.state.HBoxStoredState
 import examples.hybrid.wallet.HBoxWallet
 import io.circe.syntax._
-import scorex.core.ModifierId
 import scorex.core.api.http.{ApiResponse, ApiRouteWithFullView, ApiTry}
 import scorex.core.settings.RESTApiSettings
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
+++ b/examples/src/main/scala/examples/hybrid/blocks/PosBlock.scala
@@ -4,16 +4,16 @@ import com.google.common.primitives.{Bytes, Ints, Longs}
 import examples.commons.{PublicKey25519NoncedBox, PublicKey25519NoncedBoxSerializer, SimpleBoxTransaction, SimpleBoxTransactionCompanion}
 import io.circe.Encoder
 import io.circe.syntax._
-import scorex.core.idToBytes
 import scorex.core.block.Block
 import scorex.core.block.Block._
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.core.{ModifierId, ModifierTypeId, TransactionsCarryingPersistentNodeViewModifier, bytesToId}
+import scorex.core.{ModifierTypeId, TransactionsCarryingPersistentNodeViewModifier}
 import scorex.crypto.hash.Blake2b256
 import scorex.crypto.signatures.{Curve25519, Signature}
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/blocks/PowBlock.scala
+++ b/examples/src/main/scala/examples/hybrid/blocks/PowBlock.scala
@@ -10,9 +10,10 @@ import scorex.core.block.Block._
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.box.proposition.{PublicKey25519Proposition, PublicKey25519PropositionSerializer}
 import scorex.core.utils.ScorexEncoding
-import scorex.core.{ModifierId, _}
+import scorex.core._
 import scorex.crypto.hash.Blake2b256
 import scorex.crypto.signatures.{Curve25519, PublicKey}
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/history/HistoryStorage.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HistoryStorage.scala
@@ -5,7 +5,7 @@ import examples.commons.idToBAW
 import examples.hybrid.blocks._
 import examples.hybrid.mining.{HybridMiningSettings, PosForger}
 import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
-import scorex.core.{ModifierId, bytesToId, idToBytes}
+import scorex.util._
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.consensus.ModifierSemanticValidity.{Absent, Unknown}
 import scorex.core.utils.ScorexLogging

--- a/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridHistory.scala
@@ -16,8 +16,9 @@ import scorex.core.settings.ScorexSettings
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding, ScorexLogging}
 import scorex.core.validation.RecoverableModifierError
-import scorex.core.{ModifierId, ModifierTypeId, NodeViewModifier}
+import scorex.core.{ModifierTypeId, NodeViewModifier}
 import scorex.crypto.hash.Blake2b256
+import scorex.util.ModifierId
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/examples/src/main/scala/examples/hybrid/history/HybridSyncInfo.scala
+++ b/examples/src/main/scala/examples/hybrid/history/HybridSyncInfo.scala
@@ -5,6 +5,7 @@ import scorex.core.consensus.SyncInfo
 import scorex.core.network.message.SyncInfoMessageSpec
 import scorex.core.serialization.Serializer
 import scorex.core._
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/hybrid/mining/HybridMiningSettings.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/HybridMiningSettings.scala
@@ -6,10 +6,10 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.ValueReader
-import scorex.core.bytesToId
 import scorex.core.settings.ScorexSettings.readConfigFromPath
 import scorex.core.settings._
 import scorex.core.utils.ScorexLogging
+import scorex.util._
 
 import scala.concurrent.duration._
 

--- a/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
+++ b/examples/src/main/scala/examples/hybrid/mining/PowMiner.scala
@@ -7,13 +7,13 @@ import examples.hybrid.history.HybridHistory
 import examples.hybrid.state.HBoxStoredState
 import examples.hybrid.util.Cancellable
 import examples.hybrid.wallet.HBoxWallet
-import scorex.core.ModifierId
 import scorex.core.NodeViewHolder.CurrentView
 import scorex.core.block.Block.BlockId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
 import scorex.crypto.encode.Base58
 import scorex.crypto.hash.Blake2b256
+import scorex.util.ModifierId
 
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
+++ b/examples/src/main/scala/examples/hybrid/state/HBoxStoredState.scala
@@ -13,6 +13,7 @@ import scorex.core.transaction.state.{BoxStateChangeOperation, BoxStateChanges, 
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
 import scorex.crypto.authds._
 import scorex.mid.state.BoxMinimalState
+import scorex.util._
 
 import scala.util.{Failure, Success, Try}
 

--- a/examples/src/main/scala/examples/hybrid/wallet/HBoxWallet.scala
+++ b/examples/src/main/scala/examples/hybrid/wallet/HBoxWallet.scala
@@ -15,6 +15,7 @@ import scorex.core.transaction.wallet.{BoxWallet, BoxWalletTransaction, WalletBo
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
 import scorex.crypto.encode.Base58
 import scorex.crypto.hash.Blake2b256
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/spv/Header.scala
+++ b/examples/src/main/scala/examples/spv/Header.scala
@@ -9,6 +9,7 @@ import scorex.core.block.Block._
 import scorex.core.serialization.Serializer
 import scorex.core.utils.ScorexEncoding
 import scorex.core._
+import scorex.util._
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/spv/KLS16Proof.scala
+++ b/examples/src/main/scala/examples/spv/KLS16Proof.scala
@@ -1,8 +1,8 @@
 package examples.spv
 
 import com.google.common.primitives.{Bytes, Shorts}
-import scorex.core.ModifierId
 import scorex.core.serialization.Serializer
+import scorex.util.ModifierId
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/spv/KMZProof.scala
+++ b/examples/src/main/scala/examples/spv/KMZProof.scala
@@ -4,6 +4,7 @@ import com.google.common.primitives.{Bytes, Shorts}
 import scorex.core._
 import scorex.core.serialization.Serializer
 import scorex.core.utils.ScorexEncoding
+import scorex.util._
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/spv/SpvAlgos.scala
+++ b/examples/src/main/scala/examples/spv/SpvAlgos.scala
@@ -3,6 +3,7 @@ package examples.spv
 import io.iohk.iodb.ByteArrayWrapper
 import scorex.core._
 import scorex.core.utils.ScorexEncoding
+import scorex.util._
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
+++ b/examples/src/main/scala/examples/spv/simulation/SimulatorFuctions.scala
@@ -9,6 +9,7 @@ import scorex.core.block.Block._
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{BoxStateChanges, Insertion}
 import scorex.core._
+import scorex.util._
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/examples/src/main/scala/examples/trimchain/core/Algos.scala
+++ b/examples/src/main/scala/examples/trimchain/core/Algos.scala
@@ -15,6 +15,7 @@ import scorex.crypto.authds.avltree.batch.{BatchAVLVerifier, Lookup}
 import scorex.crypto.authds.{ADDigest, ADKey}
 import scorex.crypto.hash.{Blake2b256, Digest32}
 import scorex.crypto.signatures.{Curve25519, PublicKey}
+import scorex.util._
 
 import scala.util.{Failure, Random, Success, Try}
 

--- a/examples/src/main/scala/examples/trimchain/modifiers/BlockHeader.scala
+++ b/examples/src/main/scala/examples/trimchain/modifiers/BlockHeader.scala
@@ -7,6 +7,7 @@ import io.circe.syntax._
 import scorex.core.serialization.Serializer
 import scorex.core.utils.ScorexEncoding
 import scorex.core._
+import scorex.util._
 
 import scala.util.Try
 

--- a/examples/src/main/scala/examples/trimchain/modifiers/TBlock.scala
+++ b/examples/src/main/scala/examples/trimchain/modifiers/TBlock.scala
@@ -7,7 +7,8 @@ import io.circe.syntax._
 import scorex.core.block.Block
 import scorex.core.block.Block.{Timestamp, Version}
 import scorex.core.serialization.Serializer
-import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 import scala.annotation.tailrec
 import scala.util.Try

--- a/examples/src/main/scala/examples/trimchain/modifiers/UtxoSnapshot.scala
+++ b/examples/src/main/scala/examples/trimchain/modifiers/UtxoSnapshot.scala
@@ -2,7 +2,8 @@ package examples.trimchain.modifiers
 
 import examples.trimchain.utxo.PersistentAuthenticatedUtxo
 import scorex.core.serialization.Serializer
-import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 class UtxoSnapshot(override val parentId: ModifierId,
                    header: BlockHeader,

--- a/examples/src/main/scala/examples/trimchain/simulation/Simulators.scala
+++ b/examples/src/main/scala/examples/trimchain/simulation/Simulators.scala
@@ -7,6 +7,7 @@ import examples.trimchain.modifiers.TBlock
 import examples.trimchain.utxo.PersistentAuthenticatedUtxo
 import scorex.core._
 import scorex.core.transaction.state.PrivateKey25519Companion
+import scorex.util._
 
 trait Simulators {
 

--- a/examples/src/test/scala/hybrid/HybridGenerators.scala
+++ b/examples/src/test/scala/hybrid/HybridGenerators.scala
@@ -14,10 +14,11 @@ import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state._
 import scorex.core.transaction.wallet.WalletBox
-import scorex.core.{ModifierId, NodeViewModifier}
+import scorex.core.NodeViewModifier
 import scorex.crypto.hash.Blake2b256
 import scorex.crypto.signatures.Signature
 import scorex.testkit.utils.{FileUtils, NoShrink}
+import scorex.util.ModifierId
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._

--- a/examples/src/test/scala/hybrid/ModifierGenerators.scala
+++ b/examples/src/test/scala/hybrid/ModifierGenerators.scala
@@ -6,11 +6,12 @@ import examples.hybrid.history.HybridHistory
 import examples.hybrid.state.HBoxStoredState
 import io.iohk.iodb.ByteArrayWrapper
 import org.scalacheck.Gen
-import scorex.core.{ModifierId, bytesToId, versionToId}
+import scorex.core.versionToId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.crypto.hash.Blake2b256
 import scorex.testkit.generators.{CoreGenerators, ModifierProducerTemplateItem, SynInvalid, Valid}
+import scorex.util._
 
 import scala.collection.mutable
 

--- a/examples/src/test/scala/hybrid/NodeViewHolderGenerators.scala
+++ b/examples/src/test/scala/hybrid/NodeViewHolderGenerators.scala
@@ -8,6 +8,7 @@ import examples.hybrid.wallet.HBoxWallet
 import io.iohk.iodb.ByteArrayWrapper
 import scorex.core._
 import scorex.core.utils.NetworkTimeProvider
+import scorex.util._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/examples/src/test/scala/hybrid/NodeViewSynchronizerGenerators.scala
+++ b/examples/src/test/scala/hybrid/NodeViewSynchronizerGenerators.scala
@@ -10,6 +10,7 @@ import scorex.core.app.Version
 import scorex.core.network._
 import scorex.core.utils.NetworkTimeProvider
 import scorex.testkit.generators.CoreGenerators
+import scorex.util._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
+++ b/examples/src/test/scala/hybrid/history/HybridHistorySpecification.scala
@@ -7,7 +7,8 @@ import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
 import scorex.core.consensus.History.{Equal, HistoryComparisonResult, Older, Younger}
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.core.{ModifierId, ModifierTypeId, bytesToId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 @SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.OptionPartial"))
 class HybridHistorySpecification extends PropSpec

--- a/examples/src/test/scala/hybrid/history/IODBSpecification.scala
+++ b/examples/src/test/scala/hybrid/history/IODBSpecification.scala
@@ -7,9 +7,9 @@ import io.iohk.iodb.{ByteArrayWrapper, LSMStore}
 import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, Outcome, fixture}
-import scorex.core.ModifierId
 import scorex.core.utils.ScorexEncoding
 import scorex.testkit.utils.FileUtils
+import scorex.util.ModifierId
 
 @SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class IODBSpecification extends fixture.PropSpec

--- a/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
+++ b/examples/src/test/scala/hybrid/wallet/HWalletSpecification.scala
@@ -6,11 +6,11 @@ import examples.hybrid.wallet.HBoxWallet
 import hybrid.HybridGenerators
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
-import scorex.core.bytesToId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.proof.Signature25519
 import scorex.core.transaction.state.PrivateKey25519
 import scorex.crypto.signatures.Signature
+import scorex.util._
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/examples/src/test/scala/spv/ChainTests.scala
+++ b/examples/src/test/scala/spv/ChainTests.scala
@@ -6,11 +6,11 @@ import io.iohk.iodb.ByteArrayWrapper
 import org.scalacheck.Gen
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
-import scorex.core.ModifierId
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
 import scorex.crypto.hash
 import scorex.crypto.hash.Blake2b256
+import scorex.util.ModifierId
 
 import scala.util.{Failure, Try}
 

--- a/examples/src/test/scala/spv/SPVGenerators.scala
+++ b/examples/src/test/scala/spv/SPVGenerators.scala
@@ -3,7 +3,7 @@ package spv
 import commons.ExamplesCommonGenerators
 import examples.spv._
 import org.scalacheck.{Arbitrary, Gen}
-import scorex.core.ModifierId
+import scorex.util.ModifierId
 
 trait SPVGenerators extends ExamplesCommonGenerators {
 

--- a/examples/src/test/scala/trimchain/TrimchainGenerators.scala
+++ b/examples/src/test/scala/trimchain/TrimchainGenerators.scala
@@ -5,8 +5,8 @@ import examples.commons.SimpleBoxTransaction
 import examples.trimchain.core._
 import examples.trimchain.modifiers.{BlockHeader, TBlock}
 import org.scalacheck.{Arbitrary, Gen}
-import scorex.core.ModifierId
 import scorex.crypto.authds.SerializedAdProof
+import scorex.util.ModifierId
 
 trait TrimchainGenerators extends ExamplesCommonGenerators {
 

--- a/src/main/scala/scorex/ObjectGenerators.scala
+++ b/src/main/scala/scorex/ObjectGenerators.scala
@@ -9,8 +9,9 @@ import scorex.core.network.message.BasicMsgDataTypes._
 import scorex.core.serialization.Serializer
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.core.transaction.state.{PrivateKey25519, PrivateKey25519Companion}
-import scorex.core.{ModifierId, ModifierTypeId, NodeViewModifier, bytesToId}
+import scorex.core.{ModifierTypeId, NodeViewModifier}
 import scorex.crypto.signatures.Curve25519
+import scorex.util._
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/ModifiersCache.scala
+++ b/src/main/scala/scorex/core/ModifiersCache.scala
@@ -3,6 +3,7 @@ package scorex.core
 import scorex.core.consensus.HistoryReader
 import scorex.core.utils.ScorexLogging
 import scorex.core.validation.RecoverableModifierError
+import scorex.util.ModifierId
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/src/main/scala/scorex/core/NodeViewHolder.scala
+++ b/src/main/scala/scorex/core/NodeViewHolder.scala
@@ -11,6 +11,8 @@ import scorex.core.transaction._
 import scorex.core.transaction.state.{MinimalState, TransactionValidation}
 import scorex.core.transaction.wallet.Vault
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
+import scorex.util.ModifierId
+
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/scorex/core/NodeViewModifier.scala
+++ b/src/main/scala/scorex/core/NodeViewModifier.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import scorex.core.serialization.BytesSerializable
 import scorex.core.transaction.Transaction
 import scorex.core.utils.ScorexEncoding
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/api/http/NodeViewApiRoute.scala
+++ b/src/main/scala/scorex/core/api/http/NodeViewApiRoute.scala
@@ -12,7 +12,8 @@ import scorex.core.transaction.state.MinimalState
 import scorex.core.transaction.wallet.Vault
 import scorex.core.transaction.{MemoryPool, Transaction}
 import scorex.core.utils.ScorexEncoding
-import scorex.core.{ModifierId, PersistentNodeViewModifier, bytesToId}
+import scorex.core.PersistentNodeViewModifier
+import scorex.util._
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag

--- a/src/main/scala/scorex/core/block/Block.scala
+++ b/src/main/scala/scorex/core/block/Block.scala
@@ -5,7 +5,8 @@ import scorex.core.consensus.History
 import scorex.core.serialization.Serializer
 import scorex.core.transaction._
 import scorex.core.transaction.box.proposition.Proposition
-import scorex.core.{ModifierId, NodeViewModifier, TransactionsCarryingPersistentNodeViewModifier}
+import scorex.core.{NodeViewModifier, TransactionsCarryingPersistentNodeViewModifier}
+import scorex.util.ModifierId
 
 /**
   * A block is an atomic piece of data network participates are agreed on.

--- a/src/main/scala/scorex/core/consensus/BlockChain.scala
+++ b/src/main/scala/scorex/core/consensus/BlockChain.scala
@@ -3,7 +3,8 @@ package scorex.core.consensus
 import scorex.core.block.Block
 import scorex.core.transaction.Transaction
 import scorex.core.utils.ScorexLogging
-import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/consensus/History.scala
+++ b/src/main/scala/scorex/core/consensus/History.scala
@@ -3,6 +3,7 @@ package scorex.core.consensus
 import scorex.core._
 import scorex.core.consensus.History.ProgressInfo
 import scorex.core.utils.ScorexEncoder
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/consensus/HistoryReader.scala
+++ b/src/main/scala/scorex/core/consensus/HistoryReader.scala
@@ -1,6 +1,7 @@
 package scorex.core.consensus
 
 import scorex.core._
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/core.scala
+++ b/src/main/scala/scorex/core/core.scala
@@ -3,6 +3,7 @@ package scorex
 import scorex.core.network.message.BasicMsgDataTypes.InvData
 import scorex.core.utils.ScorexEncoder
 import scorex.crypto.encode.Base16
+import scorex.util._
 import supertagged.TaggedType
 
 package object core {
@@ -10,13 +11,9 @@ package object core {
   //TODO implement ModifierTypeId as a trait
   object ModifierTypeId extends TaggedType[Byte]
 
-  object ModifierId extends TaggedType[String]
-
   object VersionTag extends TaggedType[String]
 
   type ModifierTypeId = ModifierTypeId.Type
-
-  type ModifierId = ModifierId.Type
 
   type VersionTag = VersionTag.Type
 
@@ -32,11 +29,6 @@ package object core {
   }
 
   def idsToString(invData: InvData)(implicit encoder: ScorexEncoder): String = idsToString(invData._1, invData._2)
-
-
-  def bytesToId(bytes: Array[Byte]): ModifierId = ModifierId @@ Base16.encode(bytes)
-
-  def idToBytes(id: ModifierId): Array[Byte] = Base16.decode(id).get
 
   def bytesToVersion(bytes: Array[Byte]): VersionTag = VersionTag @@ Base16.encode(bytes)
 

--- a/src/main/scala/scorex/core/network/DeliveryTracker.scala
+++ b/src/main/scala/scorex/core/network/DeliveryTracker.scala
@@ -3,7 +3,8 @@ package scorex.core.network
 import akka.actor.{ActorRef, ActorSystem, Cancellable}
 import scorex.core.network.NodeViewSynchronizer.ReceivableMessages.CheckDelivery
 import scorex.core.utils.{ScorexEncoding, ScorexLogging}
-import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -14,6 +14,7 @@ import scorex.core.transaction.wallet.VaultReader
 import scorex.core.transaction.{MempoolReader, Transaction}
 import scorex.core.utils.{NetworkTimeProvider, ScorexEncoding, ScorexLogging}
 import scorex.core.{PersistentNodeViewModifier, _}
+import scorex.util.ModifierId
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -9,6 +9,7 @@ import scorex.core.consensus.SyncInfo
 import scorex.core.network.message.Message.MessageCode
 import scorex.core.utils.ScorexLogging
 import scorex.core._
+import scorex.util._
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/transaction/MempoolReader.scala
+++ b/src/main/scala/scorex/core/transaction/MempoolReader.scala
@@ -1,6 +1,7 @@
 package scorex.core.transaction
 
-import scorex.core.{ModifierId, NodeViewComponent}
+import scorex.core.NodeViewComponent
+import scorex.util.ModifierId
 
 /**
   * Unconfirmed transactions pool

--- a/src/main/scala/scorex/core/transaction/Transaction.scala
+++ b/src/main/scala/scorex/core/transaction/Transaction.scala
@@ -1,7 +1,8 @@
 package scorex.core.transaction
 
-import scorex.core.{EphemerealNodeViewModifier, ModifierId, ModifierTypeId, bytesToId}
+import scorex.core.{EphemerealNodeViewModifier, ModifierTypeId}
 import scorex.crypto.hash.Blake2b256
+import scorex.util._
 
 
 /**

--- a/src/main/scala/scorex/core/transaction/account/PublicKeyNoncedBox.scala
+++ b/src/main/scala/scorex/core/transaction/account/PublicKeyNoncedBox.scala
@@ -1,7 +1,6 @@
 package scorex.core.transaction.account
 
 import com.google.common.primitives.Longs
-import scorex.core.ModifierId
 import scorex.core.transaction.box.Box
 import scorex.core.transaction.box.proposition.PublicKey25519Proposition
 import scorex.crypto.authds.{ADKey, _}

--- a/src/main/scala/scorex/core/transaction/wallet/BoxWallet.scala
+++ b/src/main/scala/scorex/core/transaction/wallet/BoxWallet.scala
@@ -8,6 +8,7 @@ import scorex.core.transaction.box.proposition.{ProofOfKnowledgeProposition, Pro
 import scorex.core.transaction.state.Secret
 import scorex.core.utils.ScorexEncoding
 import scorex.core._
+import scorex.util._
 
 import scala.util.Try
 

--- a/src/main/scala/scorex/core/validation/ModifierValidator.scala
+++ b/src/main/scala/scorex/core/validation/ModifierValidator.scala
@@ -1,11 +1,11 @@
 package scorex.core.validation
 
 
-import scorex.core.ModifierId
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.utils.{ScorexEncoder, ScorexLogging}
 import scorex.core.validation.ValidationResult._
 import scorex.crypto.encode.BytesEncoder
+import scorex.util.ModifierId
 
 import scala.util.Try
 

--- a/src/test/scala/scorex/core/DefaultModifiersCacheSpecification.scala
+++ b/src/test/scala/scorex/core/DefaultModifiersCacheSpecification.scala
@@ -6,6 +6,7 @@ import scorex.core.consensus.{History, HistoryReader, ModifierSemanticValidity, 
 import scorex.core.consensus.History.ModifierIds
 import scorex.core.serialization.Serializer
 import scorex.crypto.hash.Blake2b256
+import scorex.util._
 
 import scala.util.Try
 

--- a/src/test/scala/scorex/core/validation/ValidationSpec.scala
+++ b/src/test/scala/scorex/core/validation/ValidationSpec.scala
@@ -1,10 +1,10 @@
 package scorex.core.validation
 
 import org.scalatest.{FlatSpec, Matchers}
-import scorex.core.bytesToId
 import scorex.core.consensus.ModifierSemanticValidity
 import scorex.core.utils.ScorexEncoding
 import scorex.core.validation.ValidationResult._
+import scorex.util._
 
 import scala.util.{Failure, Try}
 

--- a/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
+++ b/src/test/scala/scorex/network/DeliveryTrackerSpecification.scala
@@ -7,8 +7,9 @@ import akka.testkit.TestProbe
 import org.scalatest.prop.{GeneratorDrivenPropertyChecks, PropertyChecks}
 import org.scalatest.{Matchers, PropSpec}
 import scorex.ObjectGenerators
-import scorex.core.{ModifierId, ModifierTypeId, bytesToId}
+import scorex.core.ModifierTypeId
 import scorex.crypto.hash.Blake2b256
+import scorex.util._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/src/test/scala/scorex/network/MessageSpecification.scala
+++ b/src/test/scala/scorex/network/MessageSpecification.scala
@@ -6,7 +6,8 @@ import org.scalatest.{Matchers, PropSpec}
 import scorex.ObjectGenerators
 import scorex.core.network.message.BasicMsgDataTypes._
 import scorex.core.network.message.{InvSpec, ModifiersSpec, RequestModifierSpec}
-import scorex.core.{ModifierId, ModifierTypeId}
+import scorex.core.ModifierTypeId
+import scorex.util.ModifierId
 
 import scala.util.Try
 


### PR DESCRIPTION
Todo:
- [ ] wait for https://github.com/ScorexFoundation/Scorex/pull/271 to be merged and rebase this PR;
- [ ] wait for https://github.com/ScorexFoundation/scorex-util/pull/5 (`scorex-util` v1.1.0) to be merged;
- [ ] wait for https://github.com/input-output-hk/scrypto/pull/54 (`scrypto` v2.1.3) to be merged;
- [ ] wait for a `scorex-util` v1.1.0 (with `Base*` encoders) to be published;
- [ ] switch from snapshot version to the public v1.1.0;
- [ ] wait for a `scrypto` v2.1.3 (with `Base*` encoders moved to `scorex-util`) to be published;
- [ ] switch from snapshot version to the public v2.1.3;
 