### PR TITLE
Keep-Alive flag removed 

### DIFF
--- a/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
+++ b/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
@@ -1,0 +1,8 @@
+package scorex.core.network
+
+/**
+  * Custom exception to distinguish malicious behaviour of external peers from non-adversarial network issues
+  *
+  * @param message - exception message
+  */
+case class MaliciousBehaviorException(message: String) extends Exception(message)

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -3,7 +3,6 @@ package scorex.core.network
 import java.net._
 
 import akka.actor._
-import akka.io.Tcp.SO.KeepAlive
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
 import akka.pattern.ask
@@ -73,7 +72,7 @@ class NetworkController(settings: NetworkSettings,
   log.info(s"Declared address: ${scorexContext.externalNodeAddress}")
 
   //bind to listen incoming connections
-  tcpManager ! Bind(self, bindAddress, options = KeepAlive(true) :: Nil, pullMode = false)
+  tcpManager ! Bind(self, bindAddress, options = Nil, pullMode = false)
 
   override def receive: Receive =
     bindingLogic orElse
@@ -231,7 +230,7 @@ class NetworkController(settings: NetworkSettings,
           unconfirmedConnections += remote
           tcpManager ! Connect(
             remoteAddress = remote,
-            options = KeepAlive(true) :: Nil,
+            options = Nil,
             timeout = Some(settings.connectionTimeout),
             pullMode = true
           )

--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -200,7 +200,7 @@ class NetworkController(settings: NetworkSettings,
       log.info("Failed to execute command : " + cmd)
 
     case nonsense: Any =>
-      log.warn(s"NetworkController: got something strange $nonsense")
+      log.warn(s"NetworkController: got unexpected input $nonsense")
   }
 
   /**

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -154,7 +154,9 @@ class PeerConnectionHandler(val settings: NetworkSettings,
 
     case CloseConnection =>
       log.info(s"Enforced to abort communication with: " + connectionId + ", switching to closing mode")
-      if (outMessagesBuffer.isEmpty) connection ! Close else context become closingWithNonEmptyBuffer
+     // if (outMessagesBuffer.isEmpty)
+        writeAll()
+        connection ! Close //else context become closingWithNonEmptyBuffer
 
     case ReceivableMessages.Ack(_) => // ignore ACKs in stable mode
 
@@ -187,7 +189,8 @@ class PeerConnectionHandler(val settings: NetworkSettings,
     case CloseConnection =>
       log.info(s"Enforced to abort communication with: " + connectionId + s", switching to closing mode")
       writeAll()
-      context become closingWithNonEmptyBuffer
+      connection ! Close
+      //context become closingWithNonEmptyBuffer
   }
 
   def remoteInterface: Receive = {

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -66,6 +66,8 @@ class PeerConnectionHandler(val settings: NetworkSettings,
 
     context.system.scheduler.schedule(5.minutes, 2.minutes) {
       if ((System.currentTimeMillis() - lastSeen).millis > 2.minutes) {
+        log.info(s"Havent' heard from ${connectionDescription.connectionId.remoteAddress} for 2 mins, " +
+          s"dropping connection")
         self ! CloseConnection
       }
     }

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -188,7 +188,7 @@ class PeerConnectionHandler(val settings: NetworkSettings,
 
     case CloseConnection =>
       log.info(s"Enforced to abort communication with: " + connectionId + s", switching to closing mode")
-      writeAll()
+     // writeAll()
       connection ! Close
     //context become closingWithNonEmptyBuffer
   }

--- a/src/main/scala/scorex/core/network/PeerSpec.scala
+++ b/src/main/scala/scorex/core/network/PeerSpec.scala
@@ -37,12 +37,11 @@ case class PeerSpec(agentName: String,
 }
 
 class PeerSpecSerializer(featureSerializers: PeerFeature.Serializers) extends ScorexSerializer[PeerSpec] {
-  override def serialize(obj: PeerSpec, w: Writer): Unit = {
 
+  override def serialize(obj: PeerSpec, w: Writer): Unit = {
     w.putShortString(obj.agentName)
     ApplicationVersionSerializer.serialize(obj.protocolVersion, w)
     w.putShortString(obj.nodeName)
-
 
     w.putOption(obj.declaredAddress) { (writer, isa) =>
       val addr = isa.getAddress.getAddress

--- a/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
+++ b/src/main/scala/scorex/core/network/message/BasicMessagesRepo.scala
@@ -240,20 +240,20 @@ object HandshakeSpec {
   */
 class HandshakeSpec(featureSerializers: PeerFeature.Serializers, sizeLimit: Int) extends MessageSpecV1[Handshake] {
 
-  private val peersDataSerializer = new PeerSpecSerializer(featureSerializers)
+  private val peerDataSerializer = new PeerSpecSerializer(featureSerializers)
 
   override val messageCode: MessageCode = HandshakeSpec.messageCode
   override val messageName: String = HandshakeSpec.messageName
 
   override def serialize(obj: Handshake, w: Writer): Unit = {
     w.putULong(obj.time)
-    peersDataSerializer.serialize(obj.peerSpec, w)
+    peerDataSerializer.serialize(obj.peerSpec, w)
   }
 
   override def parse(r: Reader): Handshake = {
     require(r.remaining <= sizeLimit, s"Too big handshake. Size ${r.remaining} exceeds $sizeLimit limit")
     val t = r.getULong()
-    val data = peersDataSerializer.parse(r)
+    val data = peerDataSerializer.parse(r)
     Handshake(data, t)
   }
 }

--- a/src/main/scala/scorex/core/network/message/Message.scala
+++ b/src/main/scala/scorex/core/network/message/Message.scala
@@ -4,7 +4,7 @@ import java.nio.ByteOrder
 
 import akka.actor.DeadLetterSuppression
 import akka.util.ByteString
-import scorex.core.network.ConnectedPeer
+import scorex.core.network.{ConnectedPeer, MaliciousBehaviorException}
 import scorex.crypto.hash.Blake2b256
 
 import scala.util.{Success, Try}
@@ -67,8 +67,13 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
       val magic = it.getBytes(MagicLength)
       val msgCode = it.getByte
       val length = it.getInt
-      require(java.util.Arrays.equals(magic, magicBytes), "Wrong magic bytes" + magic.mkString)
-      require(length >= 0, "Data length is negative!")
+
+      if (!java.util.Arrays.equals(magic, magicBytes)) {
+        throw MaliciousBehaviorException("Wrong magic bytes" + magic.mkString)
+      }
+      if (length < 0) {
+        throw MaliciousBehaviorException("Data length is negative!")
+      }
 
       val spec = specsMap.getOrElse(msgCode, throw new Error(s"No message handler found for $msgCode"))
 
@@ -79,7 +84,9 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
           val checksum = it.getBytes(ChecksumLength)
           val data = it.getBytes(length)
           val digest = Blake2b256.hash(data).take(ChecksumLength)
-          if (!java.util.Arrays.equals(checksum, digest)) throw new Error(s"Invalid data checksum length = $length")
+          if (!java.util.Arrays.equals(checksum, digest)) {
+            throw MaliciousBehaviorException(s"Invalid data checksum length = $length")
+          }
           data
         } else {
           Array.empty[Byte]

--- a/src/main/scala/scorex/core/network/message/MessageSpec.scala
+++ b/src/main/scala/scorex/core/network/message/MessageSpec.scala
@@ -28,7 +28,7 @@ trait MessageSpec[Content] extends ScorexSerializer[Content] {
 }
 
 /**
-  * P2p messages, that where implemented since the beginning.
+  * P2P messages implemented in an initial version of a protocol.
   */
 trait MessageSpecV1[Content] extends MessageSpec[Content] {
 

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -4,7 +4,6 @@ import java.net.{InetAddress, InetSocketAddress}
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.io.Tcp
-import akka.io.Tcp.SO.KeepAlive
 import akka.io.Tcp.{Message => _, _}
 import akka.testkit.TestProbe
 import akka.util.ByteString
@@ -294,7 +293,7 @@ class NetworkControllerSpec extends NetworkTests {
       peerManagerRef, scorexContext, tcpManagerProbe.testActor)
 
 
-    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = KeepAlive(true) :: Nil))
+    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
 
     tcpManagerProbe.send(networkControllerRef, Bound(settings.network.bindAddress))
     networkControllerRef


### PR DESCRIPTION
Keep-alive flag in socket settings removed. This flag is probably  causing problems with node connectivity after network outages, for example, see https://github.com/ergoplatform/ergo/issues/894 