### PR TITLE
Banning peers for sending adversarially constructed messages

### DIFF
--- a/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
+++ b/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
@@ -1,0 +1,5 @@
+package scorex.core.network
+
+class MaliciousBehaviourException {
+
+}

--- a/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
+++ b/src/main/scala/scorex/core/network/MaliciousBehaviorException.scala
@@ -1,5 +1,8 @@
 package scorex.core.network
 
-class MaliciousBehaviourException {
-
-}
+/**
+  * Custom exception to distinguish malicious behaviour of external peers from non-adversarial network issues
+  *
+  * @param message - exception message
+  */
+case class MaliciousBehaviorException(message: String) extends Exception(message)

--- a/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
+++ b/src/main/scala/scorex/core/network/PeerConnectionHandler.scala
@@ -100,8 +100,8 @@ class PeerConnectionHandler(val settings: NetworkSettings,
         case Failure(t) =>
           log.info(s"Error during parsing a handshake", t)
           //ban the peer for the wrong handshake message
+          //peer will be added to the blacklist and the network controller will send CloseConnection
           selfPeer.foreach(c => networkControllerRef ! PenalizePeer(c.connectionId.remoteAddress, PenaltyType.PermanentPenalty))
-          self ! CloseConnection
       }
   }
 
@@ -198,8 +198,8 @@ class PeerConnectionHandler(val settings: NetworkSettings,
               //peer is doing bad things, ban it
               case MaliciousBehaviorException(msg) =>
                 log.warn(s"Banning peer for malicious behaviour($msg): ${connectionId.toString}")
+                //peer will be added to the blacklist and the network controller will send CloseConnection
                 networkControllerRef ! PenalizePeer(connectionId.remoteAddress, PenaltyType.PermanentPenalty)
-                self ! CloseConnection
               //non-malicious corruptions
               case _ =>
                 log.info(s"Corrupted data from ${connectionId.toString}: ${e.getMessage}")

--- a/src/main/scala/scorex/core/network/message/Message.scala
+++ b/src/main/scala/scorex/core/network/message/Message.scala
@@ -70,7 +70,7 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
 
       //peer is from another network
       if (!java.util.Arrays.equals(magic, magicBytes)) {
-        throw MaliciousBehaviorException("Wrong magic bytes" + magic.mkString)
+        throw MaliciousBehaviorException(s"Wrong magic bytes, expected ${magicBytes.mkString}, got ${magic.mkString}")
       }
 
       //peer is trying to cause buffer overflow or breaking the parsing

--- a/src/main/scala/scorex/core/network/message/Message.scala
+++ b/src/main/scala/scorex/core/network/message/Message.scala
@@ -90,7 +90,7 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
 
           //peer reported incorrect checksum
           if (!java.util.Arrays.equals(checksum, digest)) {
-            throw MaliciousBehaviorException(s"Invalid data checksum length = $length")
+            throw MaliciousBehaviorException(s"Wrong checksum, expected ${checksum.mkString}, got ${checksum.mkString}")
           }
           data
         } else {

--- a/src/main/scala/scorex/core/network/message/Message.scala
+++ b/src/main/scala/scorex/core/network/message/Message.scala
@@ -4,7 +4,7 @@ import java.nio.ByteOrder
 
 import akka.actor.DeadLetterSuppression
 import akka.util.ByteString
-import scorex.core.network.ConnectedPeer
+import scorex.core.network.{ConnectedPeer, MaliciousBehaviorException}
 import scorex.crypto.hash.Blake2b256
 
 import scala.util.{Success, Try}
@@ -67,8 +67,16 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
       val magic = it.getBytes(MagicLength)
       val msgCode = it.getByte
       val length = it.getInt
-      require(java.util.Arrays.equals(magic, magicBytes), "Wrong magic bytes" + magic.mkString)
-      require(length >= 0, "Data length is negative!")
+
+      //peer is from another network
+      if (!java.util.Arrays.equals(magic, magicBytes)) {
+        throw MaliciousBehaviorException("Wrong magic bytes" + magic.mkString)
+      }
+
+      //peer is trying to cause buffer overflow or breaking the parsing
+      if (length < 0) {
+        throw MaliciousBehaviorException("Data length is negative!")
+      }
 
       val spec = specsMap.getOrElse(msgCode, throw new Error(s"No message handler found for $msgCode"))
 
@@ -79,7 +87,11 @@ class MessageSerializer(specs: Seq[MessageSpec[_]], magicBytes: Array[Byte]) {
           val checksum = it.getBytes(ChecksumLength)
           val data = it.getBytes(length)
           val digest = Blake2b256.hash(data).take(ChecksumLength)
-          if (!java.util.Arrays.equals(checksum, digest)) throw new Error(s"Invalid data checksum length = $length")
+
+          //peer reported incorrect checksum
+          if (!java.util.Arrays.equals(checksum, digest)) {
+            throw MaliciousBehaviorException(s"Invalid data checksum length = $length")
+          }
           data
         } else {
           Array.empty[Byte]


### PR DESCRIPTION
This PR is introducing MaliciousBehaviorException indicating malicious behavior of a peer. Such exception is thrown if a peer tries to send wrong magic bytes (so a peer is from another network), or trying to declare length of a following-up buffer to be negative, or providing incorrect checksum for a message. This PR also contains some fixes for penalizing logic.  