### PR TITLE
Keep-Alive flag removed

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -3,7 +3,6 @@ package scorex.core.network
 import java.net._
 
 import akka.actor._
-import akka.io.Tcp.SO.KeepAlive
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
 import akka.pattern.ask
@@ -73,7 +72,7 @@ class NetworkController(settings: NetworkSettings,
   log.info(s"Declared address: ${scorexContext.externalNodeAddress}")
 
   //bind to listen incoming connections
-  tcpManager ! Bind(self, bindAddress, options = KeepAlive(true) :: Nil, pullMode = false)
+  tcpManager ! Bind(self, bindAddress, options = Nil, pullMode = false)
 
   override def receive: Receive =
     bindingLogic orElse
@@ -201,7 +200,7 @@ class NetworkController(settings: NetworkSettings,
       log.info("Failed to execute command : " + cmd)
 
     case nonsense: Any =>
-      log.warn(s"NetworkController: got something strange $nonsense")
+      log.warn(s"NetworkController: got unexpected input $nonsense")
   }
 
   /**
@@ -231,7 +230,7 @@ class NetworkController(settings: NetworkSettings,
           unconfirmedConnections += remote
           tcpManager ! Connect(
             remoteAddress = remote,
-            options = KeepAlive(true) :: Nil,
+            options = Nil,
             timeout = Some(settings.connectionTimeout),
             pullMode = true
           )

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -4,7 +4,6 @@ import java.net.{InetAddress, InetSocketAddress}
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.io.Tcp
-import akka.io.Tcp.SO.KeepAlive
 import akka.io.Tcp.{Message => _, _}
 import akka.testkit.TestProbe
 import akka.util.ByteString
@@ -294,7 +293,7 @@ class NetworkControllerSpec extends NetworkTests {
       peerManagerRef, scorexContext, tcpManagerProbe.testActor)
 
 
-    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = KeepAlive(true) :: Nil))
+    tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
 
     tcpManagerProbe.send(networkControllerRef, Bound(settings.network.bindAddress))
     networkControllerRef
@@ -310,7 +309,7 @@ class NetworkControllerSpec extends NetworkTests {
   */
 case class DummyUPnPGateway(override val externalAddress: InetAddress,
                             override val localAddress: InetAddress)
-                           (getLocalAddrForExtPort: (Int => Option[InetSocketAddress])) extends UPnPGateway {
+                           (getLocalAddrForExtPort: Int => Option[InetSocketAddress]) extends UPnPGateway {
 
   override def addPort(port: Int): Unit = {}
 


### PR DESCRIPTION
The problem with networking layer of Scorex is that inactive connections are not been aborted. 

This PR is introducing the first step to solve this problem, it removes keep-alive flag from socket settings, then OS dropping inactive connections after some time.  See https://lilyfeng.wordpress.com/2013/03/23/tcp-connection-and-socket-keep-alive/ for details.

However, independent (and usually more aggressive) internal connections dropping strategy is needed. This will be a topic for another PR.