### PR TITLE
moved peerSynchronizer creation to app

### DIFF
--- a/src/main/scala/scorex/core/network/NetworkController.scala
+++ b/src/main/scala/scorex/core/network/NetworkController.scala
@@ -61,11 +61,6 @@ class NetworkController(settings: NetworkSettings,
   private var connections = Map.empty[InetSocketAddress, ConnectedPeer]
   private var unconfirmedConnections = Set.empty[InetSocketAddress]
 
-  //todo: make usage more clear, now we're relying on preStart logic in a actor which is described by a never used val
-  private val featureSerializers: PeerFeature.Serializers = scorexContext.features.map(f => f.featureId -> f.serializer).toMap
-  private val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer", self, peerManagerRef, settings,
-    featureSerializers)
-
   //check own declared address for validity
   validateDeclaredAddress()
 

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -292,6 +292,9 @@ class NetworkControllerSpec extends NetworkTests {
       "networkController", settings.network,
       peerManagerRef, scorexContext, tcpManagerProbe.testActor)
 
+    val peerSynchronizer: ActorRef = PeerSynchronizerRef("PeerSynchronizer",
+      networkControllerRef, peerManagerRef, settings.network, featureSerializers)
+
 
     tcpManagerProbe.expectMsg(Bind(networkControllerRef, settings.network.bindAddress, options = Nil))
 


### PR DESCRIPTION
Addressed the following todo in Network controller
```
//todo: make usage more clear, now we're relying on preStart logic in a actor which is described by a never used val
```

This note is regarding the registration process in PeerSynchronizer that happens on creation. There seems to be no reason this actor cannot be instantiated within the primary application which will also avoid the redundant computation of the the PeerFeature serializers. 

Additionally, while not implemented in the Scorex framework, the shutdown hook has been changed in Ergo App to include a Seq of actors that should be sent a poison pill on application shutdown. By including the PeerSynchronizer in this sequence, a grayed out value would be avoided which may help dissuade an overzealous maintainer from removing the needed instantiation in the future.