### PR TITLE
Fixing "too many open files" error in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import scala.util.Try
 name := "scorex-core"
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.12.3",
+  scalaVersion := "2.12.10",
   resolvers += Resolver.sonatypeRepo("public"),
   wartremoverErrors ++= Seq(
     Wart.Recursion,

--- a/src/test/scala/scorex/network/NetworkControllerSpec.scala
+++ b/src/test/scala/scorex/network/NetworkControllerSpec.scala
@@ -336,6 +336,7 @@ class TestPeer(settings: ScorexSettings, networkControllerRef: ActorRef, tcpMana
   private val messageSpecs = Seq(GetPeersSpec, peersSpec)
   private val messagesSerializer = new MessageSerializer(messageSpecs, settings.network.magicBytes)
 
+  @SuppressWarnings(Array("org.wartremover.warts.Null"))
   private var connectionHandler: ActorRef = _
 
   /**

--- a/testkit/src/main/scala/scorex/testkit/utils/FileUtils.scala
+++ b/testkit/src/main/scala/scorex/testkit/utils/FileUtils.scala
@@ -33,21 +33,21 @@ trait FileUtils {
     createTempDirForPrefix(prefix)
   }
 
+  /**
+    * Recursively remove all the files and directories in `root`
+    */
+  def remove(root: Path): Unit = {
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  def deleteRecursive(dir: java.io.File): Unit = {
-    for (file <- dir.listFiles) {
-      if (!file.getName.startsWith(".")) {
-        if (file.isDirectory) deleteRecursive(file)
+    @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+    def deleteRecursive(dir: java.io.File): Unit = {
+      for (file <- dir.listFiles) {
+        if (file.isDirectory){
+          deleteRecursive(file)
+        }
         file.delete()
       }
     }
-  }
 
-  /**
-    * Recursively remove all files and directories in `root`
-    */
-  def remove(root: Path): Unit = {
     deleteRecursive(root.toFile)
   }
 

--- a/testkit/src/main/scala/scorex/testkit/utils/FileUtils.scala
+++ b/testkit/src/main/scala/scorex/testkit/utils/FileUtils.scala
@@ -1,8 +1,6 @@
 package scorex.testkit.utils
 
-import java.io.IOException
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+import java.nio.file.Path
 
 import org.scalacheck.Gen
 
@@ -35,21 +33,22 @@ trait FileUtils {
     createTempDirForPrefix(prefix)
   }
 
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  def deleteRecursive(dir: java.io.File): Unit = {
+    for (file <- dir.listFiles) {
+      if (!file.getName.startsWith(".")) {
+        if (file.isDirectory) deleteRecursive(file)
+        file.delete()
+      }
+    }
+  }
+
   /**
     * Recursively remove all files and directories in `root`
     */
   def remove(root: Path): Unit = {
-    Files.walkFileTree(root, new SimpleFileVisitor[Path] {
-      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.delete(file)
-        FileVisitResult.CONTINUE
-      }
-
-      override def postVisitDirectory(dir: Path, exc: IOException): FileVisitResult = {
-        Files.delete(dir)
-        FileVisitResult.CONTINUE
-      }
-    })
+    deleteRecursive(root.toFile)
   }
 
   private def createTempDirForPrefix(prefix: String): java.io.File = {


### PR DESCRIPTION
Currently "too many open files" error appears in tests. The error is rooting in how recursive deletion is implemented in scorex.testkit.utils.FileUtils.remove(). This PR fixes the problematic recursive files deletion. 

The fix is made by @knizhnik and extracted from the #362 .