### PR TITLE
Simplified check for transaction delivery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ val loggingDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.3.0-alpha4"
 )
 
-val scorexUtil = "org.scorexfoundation" %% "scorex-util" % "0.1.7"
+val scorexUtil = "org.scorexfoundation" %% "scorex-util" % "0.1.6"
 
 val testingDependencies = Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ val loggingDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.3.0-alpha4"
 )
 
-val scorexUtil = "org.scorexfoundation" %% "scorex-util" % "0.1.6"
+val scorexUtil = "org.scorexfoundation" %% "scorex-util" % "0.1.7"
 
 val testingDependencies = Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -121,7 +121,8 @@ scorex {
     # Network delivery timeout
     deliveryTimeout = 2s
 
-    # Max number of delivery checks. Stop expecting modifier (and penalize peer) if it was not delivered on time
+    # Max number of delivery checks for a persistent modifier.
+    # Stop expecting modifier (and penalize peer) if it was not delivered on time.
     maxDeliveryChecks = 2
 
     ############

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -69,20 +69,22 @@ PMOD <: PersistentNodeViewModifier, HR <: HistoryReader[PMOD, SI] : ClassTag, MR
   protected var mempoolReaderOpt: Option[MR] = None
 
   override def preStart(): Unit = {
-    //register as a handler for synchronization-specific types of messages
+    // register as a handler for synchronization-specific types of messages
     val messageSpecs: Seq[MessageSpec[_]] = Seq(invSpec, requestModifierSpec, modifiersSpec, syncInfoSpec)
     networkControllerRef ! RegisterMessageSpecs(messageSpecs, self)
 
-    //register as a listener for peers got connected (handshaked) or disconnected
+    // register as a listener for peers got connected (handshaked) or disconnected
     context.system.eventStream.subscribe(self, classOf[HandshakedPeer])
     context.system.eventStream.subscribe(self, classOf[DisconnectedPeer])
 
-    //subscribe for all the node view holder events involving modifiers and transactions
+    // subscribe for all the node view holder events involving modifiers and transactions
     context.system.eventStream.subscribe(self, classOf[ChangedHistory[HR]])
     context.system.eventStream.subscribe(self, classOf[ChangedMempool[MR]])
     context.system.eventStream.subscribe(self, classOf[ModificationOutcome])
     context.system.eventStream.subscribe(self, classOf[DownloadRequest])
     context.system.eventStream.subscribe(self, classOf[ModifiersProcessingResult[PMOD]])
+
+    // subscribe for history and mempool changes
     viewHolderRef ! GetNodeViewChanges(history = true, state = false, vault = false, mempool = true)
 
     statusTracker.scheduleSendSyncInfo()

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -32,27 +32,29 @@ import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 
 /**
-  * A component which is synchronizing local node view (locked inside NodeViewHolder) with the p2p network.
+  * A component which is synchronizing local node view (processed by NodeViewHolder) with the p2p network.
   *
+  * @tparam TX   transaction
+  * @tparam SIS  SyncInfoMessage specification
+  * @tparam PMOD Basic trait of persistent modifiers type family
+  * @tparam HR   History reader type
+  * @tparam MR   Mempool reader type
   * @param networkControllerRef reference to network controller actor
   * @param viewHolderRef        reference to node view holder actor
   * @param syncInfoSpec         SyncInfo specification
-  * @tparam TX  transaction
-  * @tparam SIS SyncInfoMessage specification
+  * @param networkSettings      network settings instance
+  * @param timeProvider         network time provider
+  * @param modifierSerializers  dictionary of modifiers serializers
   */
-class NodeViewSynchronizer[TX <: Transaction,
-SI <: SyncInfo,
-SIS <: SyncInfoMessageSpec[SI],
-PMOD <: PersistentNodeViewModifier,
-HR <: HistoryReader[PMOD, SI] : ClassTag,
-MR <: MempoolReader[TX] : ClassTag]
+class NodeViewSynchronizer[TX <: Transaction, SI <: SyncInfo, SIS <: SyncInfoMessageSpec[SI],
+PMOD <: PersistentNodeViewModifier, HR <: HistoryReader[PMOD, SI] : ClassTag, MR <: MempoolReader[TX] : ClassTag]
 (networkControllerRef: ActorRef,
  viewHolderRef: ActorRef,
  syncInfoSpec: SIS,
  networkSettings: NetworkSettings,
  timeProvider: NetworkTimeProvider,
- modifierSerializers: Map[ModifierTypeId, ScorexSerializer[_ <: NodeViewModifier]])(implicit ec: ExecutionContext) extends Actor
-  with ScorexLogging with ScorexEncoding {
+ modifierSerializers: Map[ModifierTypeId, ScorexSerializer[_ <: NodeViewModifier]])(implicit ec: ExecutionContext)
+  extends Actor with ScorexLogging with ScorexEncoding {
 
   protected val deliveryTimeout: FiniteDuration = networkSettings.deliveryTimeout
   protected val maxDeliveryChecks: Int = networkSettings.maxDeliveryChecks

--- a/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
+++ b/src/main/scala/scorex/core/network/NodeViewSynchronizer.scala
@@ -374,9 +374,9 @@ PMOD <: PersistentNodeViewModifier, HR <: HistoryReader[PMOD, SI] : ClassTag, MR
             penalizeNonDeliveringPeer(peer)
             deliveryTracker.onStillWaiting(peer, modifierTypeId, modifierId)
           case None =>
-            // Random peer did not delivered modifier we need, ask another peer
+            // Random peer has not delivered modifier we need, ask another peer
             // We need this modifier - no limit for number of attempts
-            log.info(s"Modifier ${encoder.encodeId(modifierId)} was not delivered on time")
+            log.info(s"Modifier ${encoder.encodeId(modifierId)} has not delivered on time")
             deliveryTracker.setUnknown(modifierId)
             requestDownload(modifierTypeId, Seq(modifierId))
         }


### PR DESCRIPTION
This PR is introducing relaxed rules for transaction delivery check.

Unlike persistent modifiers, non-delivery for a transaction is not a reason to request it again and penalize a peer for non-delivery, as the transaction can be removed for a good reason from other peer's mempool.