### PR TITLE
pass details message by name into ValidationState.validate

### DIFF
--- a/src/main/scala/scorex/core/validation/ModifierValidator.scala
+++ b/src/main/scala/scorex/core/validation/ModifierValidator.scala
@@ -89,12 +89,12 @@ case class ValidationState[T](result: ValidationResult[T], settings: ValidationS
 
   /** Validate the condition is `true` or else return the `error` given
     */
-  def validate(id: Short, condition: => Boolean, details: String = ""): ValidationState[T] = {
+  def validate(id: Short, condition: => Boolean, details: => String = ""): ValidationState[T] = {
     pass(if (!settings.isActive(id) || condition) result else settings.getError(id, details))
   }
 
   /** Reverse condition: Validate the condition is `false` or else return the `error` given */
-  def validateNot(id: Short, condition: => Boolean, details: String = ""): ValidationState[T] = {
+  def validateNot(id: Short, condition: => Boolean, details: => String = ""): ValidationState[T] = {
     validate(id, !condition, details)
   }
 
@@ -122,7 +122,7 @@ case class ValidationState[T](result: ValidationResult[T], settings: ValidationS
 
   /** Wrap semantic validity to the validation state: if semantic validity was not Valid, then return the `error` given
     */
-  def validateSemantics(id: Short, validity: => ModifierSemanticValidity, details: String = ""): ValidationState[T] = {
+  def validateSemantics(id: Short, validity: => ModifierSemanticValidity, details: => String = ""): ValidationState[T] = {
     validateNot(id, validity == ModifierSemanticValidity.Invalid, details)
   }
 


### PR DESCRIPTION
This simple change will allow avoid constructing error messages for all validation checks when error doesn't happen (which is the main case).

E.g. the following Ergo code has many unnecessary string building operations.
```scala
validationState
        .validate(txDust, out.value >= BoxUtils.minimalErgoAmount(out, stateContext.currentParameters), s"$id, output ${Algos.encode(out.id)}, ${out.value} >= ${BoxUtils.minimalErgoAmount(out, stateContext.currentParameters)}")
        .validate(txFuture, out.creationHeight <= stateContext.currentHeight, s" ${out.creationHeight} <= ${stateContext.currentHeight} is not true, output id: $id: output $out")
        .validate(txBoxSize, out.bytes.length <= MaxBoxSize.value, s"$id: output $out")
        .validate(txBoxPropositionSize, out.propositionBytes.length <= MaxPropositionBytes.value, s"$id: output $out")
```