### PR TITLE
HTTPS resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ name := "scorex-core"
 lazy val commonSettings = Seq(
   scalaVersion := "2.12.10",
   resolvers += Resolver.sonatypeRepo("public"),
+  resolvers += "Maven Central Server" at "https://repo1.maven.org/maven2",
+  resolvers += "Typesafe Server" at "https://repo.typesafe.com/typesafe/releases",
   wartremoverErrors ++= Seq(
     Wart.Recursion,
     Wart.TraversableOps,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 


### PR DESCRIPTION
HTTPS resolvers added to build.sbt and plugins.sbt to avoid errors during artifacts downloading.  